### PR TITLE
TTS speak/append split + Gemma 4 MTP build + streamer/audio-io 安定化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,38 @@
 #LLM_MODEL=gemma4:e4b
 
 # -----------------------------------------------------------------------
+# HF_TOKEN — Hugging Face personal access token.
+#
+# Required ONLY when building the Gemma 4 MTP (multi-token
+# prediction) variant locally via `ollama create` — both the target
+# and the drafter models are gated behind Google's Gemma license on
+# Hugging Face. For the default `gemma4:e4b` (no MTP) path the
+# token is unused and you can leave this blank.
+#
+# How to obtain:
+#   1. Create a Hugging Face account at https://huggingface.co
+#   2. Visit each of the gated repos and click "Agree to license":
+#        https://huggingface.co/google/gemma-4-E4B-it
+#        https://huggingface.co/google/gemma-4-E4B-it-assistant
+#      The approval is usually instant. You need acceptance under
+#      the *same* HF account that owns the token below.
+#   3. Settings → Access Tokens → New token
+#        Type: "Read"
+#        Permissions: "Read access to contents of all repos under
+#        your personal namespace" + "Read access to contents of all
+#        public gated repos you can access"
+#      Copy the value — it starts with `hf_…`.
+#   4. Paste it here. Compose forwards it to the `llm` service as
+#      `HF_TOKEN` so the init.sh download step can authenticate.
+#
+# Confirming a token works (outside the container):
+#   curl -fsS -H "Authorization: Bearer ${HF_TOKEN}" \
+#     https://huggingface.co/api/models/google/gemma-4-E4B-it
+#
+# Default: empty (MTP path disabled, plain `ollama pull` is used).
+#HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# -----------------------------------------------------------------------
 # ASR_MODEL — whisper.cpp GGML model file. Fetched into the
 # `asr-models` volume on first run. Must exist as a file at
 # `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/<name>`:

--- a/audio-io/src/playback.rs
+++ b/audio-io/src/playback.rs
@@ -431,27 +431,44 @@ async fn playback_producer_task(
         }
     };
     let ring_capacity = producer.capacity().get();
+    // Idle silence keep-alive threshold. When no Frame messages are
+    // arriving, top up the ring with 0.0 samples so the OS-level
+    // audio pipeline (WASAPI prefetch / ALSA period buffer) stays warm
+    // — without this, the first sentence of the second-and-later turns
+    // was head-clipped because the pipeline had gone cold during the
+    // inter-turn idle period. 50ms is enough margin to absorb the
+    // ~10ms cpal callback jitter without delaying real audio (the
+    // top-up only fires while ring_depth < threshold; real audio
+    // pushes the depth far above this).
+    let keep_alive_threshold = (native_rate as usize) * (native_channels as usize) * 50 / 1000;
     let mut total_dropped: u64 = 0;
     let mut drops_since_log: u32 = 0;
-    while let Some(msg) = spk_rx.recv().await {
-        if flush.producer.swap(false, Ordering::Relaxed) {
-            // Cancellation (barge-in) — drain everything queued and
-            // reset the framer. Any in-flight Eos requests get their
-            // drain_done fired immediately because the cancel itself
-            // is the "no more audio is coming" signal that the
-            // upstream is waiting for.
-            while let Ok(pending) = spk_rx.try_recv() {
-                if let PlaybackMessage::Eos { drain_done } = pending {
-                    let _ = drain_done.send(());
+    loop {
+        tokio::select! {
+            // Frame / Eos / shutdown gets strictly preferred over the
+            // idle keep-alive: if a Frame is ready, we'd rather push
+            // real audio than synthetic silence.
+            biased;
+            recv = spk_rx.recv() => {
+                let Some(msg) = recv else { break; };
+                if flush.producer.swap(false, Ordering::Relaxed) {
+                    // Cancellation (barge-in) — drain everything queued and
+                    // reset the framer. Any in-flight Eos requests get their
+                    // drain_done fired immediately because the cancel itself
+                    // is the "no more audio is coming" signal that the
+                    // upstream is waiting for.
+                    while let Ok(pending) = spk_rx.try_recv() {
+                        if let PlaybackMessage::Eos { drain_done } = pending {
+                            let _ = drain_done.send(());
+                        }
+                    }
+                    framer.flush();
+                    if let PlaybackMessage::Eos { drain_done } = msg {
+                        let _ = drain_done.send(());
+                    }
+                    continue;
                 }
-            }
-            framer.flush();
-            if let PlaybackMessage::Eos { drain_done } = msg {
-                let _ = drain_done.send(());
-            }
-            continue;
-        }
-        match msg {
+                match msg {
             PlaybackMessage::Frame(bytes) => {
                 // Mark this tick as "audio flowing" so the underrun
                 // logger emits warns gated on actual sender activity
@@ -496,13 +513,14 @@ async fn playback_producer_task(
             }
             PlaybackMessage::Eos { drain_done } => {
                 // Wait for the cpal output thread to consume every
-                // sample we've pushed. Polling vacant_len from the
-                // producer side reads how much room is available; when
-                // it equals capacity, the ring is empty and the cpal
-                // callback has just emitted (or is about to emit) its
-                // last non-zero sample. 5 ms granularity is well below
-                // a 20 ms frame so the upstream sees the drained
-                // signal within ~one cpal callback of true silence.
+                // real sample we've pushed. The Eos arm runs inside
+                // the select; while we're in this drain loop, the
+                // idle keep-alive arm below is NOT polled (tokio
+                // select picks one branch and runs it to completion
+                // before reconsidering the others), so the ring is
+                // free to drain to empty without silence top-ups
+                // racing the cpal consumer.
+                //
                 // A flush mid-wait is treated as "drained now" — the
                 // cancel path drained the ring on our behalf.
                 let drain_start = Instant::now();
@@ -515,6 +533,25 @@ async fn playback_producer_task(
                 let drain_ms = drain_start.elapsed().as_millis();
                 info!(drain_ms, "playback ring drained, signaling client");
                 let _ = drain_done.send(());
+            }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(10)) => {
+                // Idle keep-alive: when the ring drops below
+                // keep_alive_threshold (50 ms), top it up to that
+                // threshold with 0.0 silence. Keeps the OS audio
+                // pipeline pre-fetched so the next real audio doesn't
+                // pay a wake-up latency on the speaker. Cheap no-op
+                // while real audio is flowing (ring depth >> 50 ms).
+                let depth = ring_capacity - producer.vacant_len();
+                if depth < keep_alive_threshold {
+                    let need = keep_alive_threshold - depth;
+                    for _ in 0..need {
+                        if producer.try_push(0.0).is_err() {
+                            break;
+                        }
+                    }
+                }
             }
         }
     }

--- a/audio-io/src/playback.rs
+++ b/audio-io/src/playback.rs
@@ -447,16 +447,18 @@ async fn playback_producer_task(
         tokio::select! {
             // Frame / Eos / shutdown gets strictly preferred over the
             // idle keep-alive: if a Frame is ready, we'd rather push
-            // real audio than synthetic silence.
+            // real audio than synthetic silence. `biased` means tokio
+            // polls the `recv` arm first every iteration before even
+            // looking at the keep-alive sleep.
             biased;
             recv = spk_rx.recv() => {
                 let Some(msg) = recv else { break; };
                 if flush.producer.swap(false, Ordering::Relaxed) {
-                    // Cancellation (barge-in) — drain everything queued and
-                    // reset the framer. Any in-flight Eos requests get their
-                    // drain_done fired immediately because the cancel itself
-                    // is the "no more audio is coming" signal that the
-                    // upstream is waiting for.
+                    // Cancellation (barge-in) — drain everything queued
+                    // and reset the framer. Any in-flight Eos requests
+                    // get their drain_done fired immediately because
+                    // the cancel itself is the "no more audio is
+                    // coming" signal that the upstream is waiting for.
                     while let Ok(pending) = spk_rx.try_recv() {
                         if let PlaybackMessage::Eos { drain_done } = pending {
                             let _ = drain_done.send(());
@@ -469,71 +471,89 @@ async fn playback_producer_task(
                     continue;
                 }
                 match msg {
-            PlaybackMessage::Frame(bytes) => {
-                // Mark this tick as "audio flowing" so the underrun
-                // logger emits warns gated on actual sender activity
-                // instead of spamming while idle.
-                stats.audio_seen.store(true, Ordering::Relaxed);
-                let samples = framer.push_s16le(&bytes);
-                let mut overflow = false;
-                let mut dropped_this_batch: usize = 0;
-                for s in samples {
-                    if overflow {
-                        dropped_this_batch += 1;
-                        continue;
+                    PlaybackMessage::Frame(bytes) => {
+                        // Mark this tick as "audio flowing" so the
+                        // underrun logger emits warns gated on actual
+                        // sender activity instead of spamming while
+                        // idle.
+                        stats.audio_seen.store(true, Ordering::Relaxed);
+                        let samples = framer.push_s16le(&bytes);
+                        let mut overflow = false;
+                        let mut dropped_this_batch: usize = 0;
+                        for s in samples {
+                            if overflow {
+                                dropped_this_batch += 1;
+                                continue;
+                            }
+                            if producer.try_push(s).is_err() {
+                                overflow = true;
+                                dropped_this_batch += 1;
+                            }
+                        }
+                        if dropped_this_batch > 0 {
+                            total_dropped =
+                                total_dropped.saturating_add(dropped_this_batch as u64);
+                            // Per-batch debug line so an operator
+                            // running with `RUST_LOG=audio_io::playback=debug`
+                            // (or just =debug) can confirm whether
+                            // their WS sender is overpacing the cpal
+                            // consumer — even a single dropped sample
+                            // shows up here, which the rate-limited
+                            // warn below hides until 50 batches have
+                            // piled up.
+                            debug!(
+                                dropped_this_batch,
+                                total_dropped,
+                                "playback ring full; dropping samples (WS arriving faster than cpal consumes)"
+                            );
+                            drops_since_log += 1;
+                            // Rate-limit: roughly once per ~1s at
+                            // 20ms/frame.
+                            if drops_since_log >= 50 {
+                                warn!(
+                                    total_dropped,
+                                    "playback ring buffer full; dropping samples (consumer slower than producer)"
+                                );
+                                drops_since_log = 0;
+                            }
+                        }
                     }
-                    if producer.try_push(s).is_err() {
-                        overflow = true;
-                        dropped_this_batch += 1;
+                    PlaybackMessage::Eos { drain_done } => {
+                        // Wait for the cpal output thread to consume
+                        // every real sample we've pushed. The Eos arm
+                        // runs inside the select; once tokio picks
+                        // this branch it polls *only* this future
+                        // until it returns Poll::Ready — the inner
+                        // `sleep(5ms).await` is a yield point within
+                        // the same future, not a re-entry into the
+                        // select, so the idle keep-alive arm is NOT
+                        // polled and cannot race silence top-ups into
+                        // the ring we're trying to drain to empty.
+                        //
+                        // A flush mid-wait is treated as "drained now"
+                        // — the cancel path drained the ring on our
+                        // behalf.
+                        let drain_start = Instant::now();
+                        while producer.vacant_len() < ring_capacity {
+                            if flush.producer.load(Ordering::Relaxed) {
+                                break;
+                            }
+                            tokio::time::sleep(Duration::from_millis(5)).await;
+                        }
+                        let drain_ms = drain_start.elapsed().as_millis();
+                        info!(drain_ms, "playback ring drained, signaling client");
+                        let _ = drain_done.send(());
+                        // Note: on the next loop iteration the
+                        // keep-alive arm will see an empty ring and
+                        // refill up to keep_alive_threshold (50 ms of
+                        // silence). The drain handshake has already
+                        // fired so the upstream is unblocked; that 50
+                        // ms tail is harmless filler. The subsequent
+                        // /speak path POSTs /spk/stop, which sets the
+                        // flush flag and erases this filler before the
+                        // next real Frame is pushed — so no head-clip
+                        // risk for the next turn.
                     }
-                }
-                if dropped_this_batch > 0 {
-                    total_dropped = total_dropped.saturating_add(dropped_this_batch as u64);
-                    // Per-batch debug line so an operator running with
-                    // `RUST_LOG=audio_io::playback=debug` (or just =debug)
-                    // can confirm whether their WS sender is overpacing
-                    // the cpal consumer — even a single dropped sample
-                    // shows up here, which the rate-limited warn below
-                    // hides until 50 batches have piled up.
-                    debug!(
-                        dropped_this_batch,
-                        total_dropped,
-                        "playback ring full; dropping samples (WS arriving faster than cpal consumes)"
-                    );
-                    drops_since_log += 1;
-                    // Rate-limit: roughly once per ~1s at 20ms/frame.
-                    if drops_since_log >= 50 {
-                        warn!(
-                            total_dropped,
-                            "playback ring buffer full; dropping samples (consumer slower than producer)"
-                        );
-                        drops_since_log = 0;
-                    }
-                }
-            }
-            PlaybackMessage::Eos { drain_done } => {
-                // Wait for the cpal output thread to consume every
-                // real sample we've pushed. The Eos arm runs inside
-                // the select; while we're in this drain loop, the
-                // idle keep-alive arm below is NOT polled (tokio
-                // select picks one branch and runs it to completion
-                // before reconsidering the others), so the ring is
-                // free to drain to empty without silence top-ups
-                // racing the cpal consumer.
-                //
-                // A flush mid-wait is treated as "drained now" — the
-                // cancel path drained the ring on our behalf.
-                let drain_start = Instant::now();
-                while producer.vacant_len() < ring_capacity {
-                    if flush.producer.load(Ordering::Relaxed) {
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_millis(5)).await;
-                }
-                let drain_ms = drain_start.elapsed().as_millis();
-                info!(drain_ms, "playback ring drained, signaling client");
-                let _ = drain_done.send(());
-            }
                 }
             }
             _ = tokio::time::sleep(Duration::from_millis(10)) => {

--- a/compose.yaml
+++ b/compose.yaml
@@ -359,7 +359,7 @@ services:
       # and restarting the agent takes effect on existing sessions'
       # next turn). Single-line in .env; for multi-paragraph
       # instructions edit this YAML directly (supports literal blocks).
-      AGENT_SYSTEM_PROMPT: "${AGENT_SYSTEM_PROMPT:-You are a voice assistant; your replies are spoken aloud, so write the way people speak — no markdown, no lists, no code blocks. Keep every response to one or two short sentences. Default to Japanese (日本語) unless the user clearly speaks another language. Maintain a brisk, natural conversational rhythm. Keep wording as simple and minimal as possible — fewer words is better. Skip honorifics (敬語); use casual / plain-form Japanese (タメ口).}"
+      AGENT_SYSTEM_PROMPT: "${AGENT_SYSTEM_PROMPT:-You are a voice assistant; your replies are spoken aloud, so write the way people speak — no markdown, no lists, no code blocks. Keep every response to one or two short sentences. Default to Japanese (日本語) unless the user clearly speaks another language. Maintain a brisk, natural conversational rhythm. Keep wording as simple and minimal as possible — fewer words is better. Skip honorifics (敬語); use casual / plain-form Japanese (タメ口). Input text is produced by ASR (speech-to-text); read it with that in mind — expect transcription noise, dropped particles, and homophone mistakes. If the input doesn't seem to make sense, assume the user's speech may have been only partially or incorrectly transcribed, and respond accordingly (briefly confirm or pick the most plausible meaning).}"
       # Rotate the LangGraph thread_id (= conversation memory key)
       # after this many seconds without /api/chat traffic. Voice agent
       # assumes one operator per process, so going idle = "the

--- a/compose.yaml
+++ b/compose.yaml
@@ -151,12 +151,22 @@ services:
       # cache vs the f16 default at negligible quality loss. Needs
       # OLLAMA_FLASH_ATTENTION=1.
       OLLAMA_KV_CACHE_TYPE: "q8_0"
-      # Context window. Voice multi-turn benefits from a longer
-      # window so the agent's checkpointed history isn't truncated
-      # after a handful of turns. 32k at q8_0 KV ≈ ~1 GiB of cache —
-      # well inside the 4090-Laptop's headroom (gemma4:e4b weights
-      # are ~9 GiB, leaving ~3 GiB free at 4096; 32k still fits).
-      OLLAMA_CONTEXT_LENGTH: "${OLLAMA_CONTEXT_LENGTH:-32768}"
+      # Context window. Voice multi-turn benefits from a long enough
+      # window to keep a handful of turns in checkpointed history, but
+      # the cost is KV cache size + per-token attention compute.
+      # 8 k @ q8 KV ≈ ~250 MiB cache (vs ~1 GiB at 32k) and trims
+      # ~5-10 % off per-token latency on a 4090 Laptop. Voice replies
+      # almost never need more than a few hundred tokens of context
+      # for the agent to keep state coherent, so 8 k is the sweet
+      # spot for this workload. Bump if you find the agent forgetting
+      # mid-conversation.
+      OLLAMA_CONTEXT_LENGTH: "${OLLAMA_CONTEXT_LENGTH:-8192}"
+      # Force the quantised matrix-multiplication CUDA kernel (MMQ)
+      # instead of the cuBLAS-on-dequantised path. For Q4_K_M models
+      # on Ada (RTX 4090 / 4090 Laptop, compute 8.9) MMQ is reliably
+      # 10-30 % faster at token generation. The flag is harmless on
+      # GPUs where MMQ isn't a win — ggml falls back gracefully.
+      GGML_CUDA_FORCE_MMQ: "1"
       # One inference at a time — the orchestrator already serialises
       # turns at max_inflight=1, so allowing parallel slots would only
       # split the KV cache and hurt single-turn latency.

--- a/compose.yaml
+++ b/compose.yaml
@@ -164,6 +164,11 @@ services:
       # Don't let a stray /api/show or warm-pull hold a second model
       # resident: voice agent only needs the one configured weight.
       OLLAMA_MAX_LOADED_MODELS: "1"
+      # Forwarded to huggingface-cli inside init.sh — only consulted
+      # when LLM_MODEL ends in `-mtp` (target + drafter safetensors
+      # for the MTP build path are gated Gemma weights). Plain ollama
+      # pull tags (e.g. `gemma4:e4b`) don't need this.
+      HF_TOKEN: "${HF_TOKEN:-}"
     volumes:
       - ollama-data:/root/.ollama
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -405,6 +405,11 @@ services:
       # anyway, but keeping this empty makes the contract explicit.
       ORCH_LLM_SYSTEM_PROMPT: ""
       ORCH_TTS_URL: http://tts-streamer:7070/speak
+      # /append (api②) — used for the 2nd-and-later sentences of each
+      # turn so the streamer reuses its burst budget instead of
+      # re-prebuffering 5 s every sentence (which overflows audio-io's
+      # ring; issue #16). Empty falls back to /speak for every sentence.
+      ORCH_TTS_APPEND_URL: http://tts-streamer:7070/append
       ORCH_TTS_STOP_URL: http://tts-streamer:7070/stop
       # Drain handshake target. Called once per turn after the last
       # /speak — tts-streamer's response is the precise speaker-

--- a/compose.yaml
+++ b/compose.yaml
@@ -463,3 +463,19 @@ volumes:
   asr-models:
   ollama-data:
   agent-data:
+
+# Pin the default bridge subnet so the UFW rule that allows
+# `audio-io` (host port 7010) inbound stays valid across
+# `docker compose down/up`. Without an explicit ipam.config, Docker
+# picks a free subnet each time the network is recreated — the rule
+# would silently stop matching and containers would lose audio-io
+# again. Gateway 172.25.0.1 is the host's br-xxxxx IP that ssh -R
+# binds to.
+networks:
+  default:
+    name: kklocalagent_default
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.25.0.0/16
+          gateway: 172.25.0.1

--- a/llm/Dockerfile
+++ b/llm/Dockerfile
@@ -8,15 +8,26 @@
 #
 # Model cache lives at /root/.ollama — mount a named volume there so
 # the first-boot pull persists across `docker compose down && up`.
-ARG OLLAMA_TAG=latest
+# Pinned to a named release rather than `latest` so the image is
+# reproducible. 0.23.2 is the first stable release that bundles
+# PR #15980 (Gemma 4 multi-token prediction speculative decoding) —
+# bump alongside the drafter / target model upgrade when we wire it
+# up. Override at build time with `--build-arg OLLAMA_TAG=…`.
+ARG OLLAMA_TAG=0.23.2
 
 FROM ollama/ollama:${OLLAMA_TAG}
 
 # curl is needed for the HEALTHCHECK probe and for init.sh to poll
-# /api/tags before issuing the pull. Not guaranteed in upstream.
+# /api/tags before issuing the pull. python3 + huggingface_hub is
+# only used by the MTP path in init.sh (LLM_MODEL ends in `-mtp`),
+# where the target + drafter safetensors live behind Google's
+# gated Gemma license on HF and need an authenticated download
+# before `ollama create` can ingest them.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends curl python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir --break-system-packages \
+        "huggingface_hub[cli]>=0.25,<1.0"
 
 # Default model per design v0.2 (#4 §9). Override at runtime via
 # compose `environment:` — the HEALTHCHECK CMD below is a shell-form

--- a/llm/init.sh
+++ b/llm/init.sh
@@ -114,10 +114,15 @@ EOF
             # with `MTP_QUANTIZE=` (empty) to keep BF16 on a card with
             # ≥ 24 GiB, or with e.g. `q4_K_M` for tighter memory at
             # some quality cost.
+            # Ollama 0.23.2 only exposes `--quantize` (applies to the
+            # target model). `--quantize-draft` was mentioned in the
+            # PR thread but isn't on the CLI yet — the drafter stays
+            # at its native dtype, which is fine because it's tiny
+            # (the 4-layer assistant is a few hundred MB regardless).
             QUANTIZE="${MTP_QUANTIZE-q8_0}"
             QUANTIZE_FLAGS=()
             if [ -n "${QUANTIZE}" ]; then
-                QUANTIZE_FLAGS+=(--quantize "${QUANTIZE}" --quantize-draft "${QUANTIZE}")
+                QUANTIZE_FLAGS+=(--quantize "${QUANTIZE}")
             fi
             echo "[init] ollama create --experimental ${MODEL} (quantize=${QUANTIZE:-bf16})"
             ollama create --experimental "${MODEL}" -f "${BUILD_DIR}/Modelfile" "${QUANTIZE_FLAGS[@]}"

--- a/llm/init.sh
+++ b/llm/init.sh
@@ -103,6 +103,10 @@ case "${MODEL}" in
                 exit 1
             fi
             BUILD_DIR="/tmp/mtp-build-$$"
+            # set -e で huggingface-cli / ollama create が落ちると後段の
+            # `rm -rf "${BUILD_DIR}"` を踏まずに抜けるため、~20 GiB の
+            # safetensors が /tmp に残留する。trap で確実に掃除する。
+            trap 'rm -rf "${BUILD_DIR:-}"' EXIT
             mkdir -p "${BUILD_DIR}/target" "${BUILD_DIR}/draft"
             echo "[init] downloading target ${TARGET_REPO}"
             HF_TOKEN="${HF_TOKEN}" huggingface-cli download "${TARGET_REPO}" \

--- a/llm/init.sh
+++ b/llm/init.sh
@@ -105,8 +105,22 @@ case "${MODEL}" in
 FROM ${BUILD_DIR}/target
 DRAFT ${BUILD_DIR}/draft
 EOF
-            echo "[init] ollama create --experimental ${MODEL}"
-            ollama create --experimental "${MODEL}" -f "${BUILD_DIR}/Modelfile"
+            # Quantize at import time. The PR conversation noted that
+            # unquantized BF16 has the best output quality but the
+            # target weights alone (~14 GiB for E4B BF16) plus KV
+            # cache + activations push past 16 GiB on a 4090 Laptop.
+            # q8_0 halves the model size at near-lossless quality and
+            # leaves headroom for the 32 k context KV cache. Override
+            # with `MTP_QUANTIZE=` (empty) to keep BF16 on a card with
+            # ≥ 24 GiB, or with e.g. `q4_K_M` for tighter memory at
+            # some quality cost.
+            QUANTIZE="${MTP_QUANTIZE-q8_0}"
+            QUANTIZE_FLAGS=()
+            if [ -n "${QUANTIZE}" ]; then
+                QUANTIZE_FLAGS+=(--quantize "${QUANTIZE}" --quantize-draft "${QUANTIZE}")
+            fi
+            echo "[init] ollama create --experimental ${MODEL} (quantize=${QUANTIZE:-bf16})"
+            ollama create --experimental "${MODEL}" -f "${BUILD_DIR}/Modelfile" "${QUANTIZE_FLAGS[@]}"
             # Cleanup: ollama create copied the weights into its own
             # blob store under /root/.ollama; the staging dir is no
             # longer needed and would otherwise waste ~10 GB per build.

--- a/llm/init.sh
+++ b/llm/init.sh
@@ -56,35 +56,39 @@ done
 #   26B / 31B → datacenter cards only.
 #
 # Pre-quantised gemma4 MTP tags in the Ollama library (e.g. the
-# existing `gemma4:31b-coding-mtp-bf16`) will eventually obviate
-# this whole branch; until then this is the only way on Linux.
+# existing `gemma4:31b-coding-mtp-bf16`) will eventually obviate this
+# whole branch; until then this is the only way on Linux.
+#
+# Match the four known "build-from-HF" tags exactly. Anything else —
+# including future pre-quantised library tags like `*-mtp-bf16` — falls
+# through to plain `ollama pull` so a glob like `*-mtp-*` doesn't trap
+# them into the build path and exit 1 on what is really an off-the-shelf
+# pull.
+#
+# Recommended num_speculative_tokens per variant (for future re-wiring
+# once upstream surfaces the knob in `ollama create`'s allowlist):
+#   gemma4:e2b-mtp   → 2
+#   gemma4:e4b-mtp   → 4
+#   gemma4:26b-mtp   → 4
+#   gemma4:31b-mtp   → 4
 case "${MODEL}" in
-    *-mtp|*-mtp-*)
+    gemma4:e4b-mtp|gemma4:e2b-mtp|gemma4:26b-mtp|gemma4:31b-mtp)
         case "${MODEL}" in
             gemma4:e4b-mtp)
                 TARGET_REPO="google/gemma-4-E4B-it"
                 DRAFT_REPO="google/gemma-4-E4B-it-assistant"
-                NUM_SPEC_TOKENS=4
                 ;;
             gemma4:e2b-mtp)
                 TARGET_REPO="google/gemma-4-E2B-it"
                 DRAFT_REPO="google/gemma-4-E2B-it-assistant"
-                NUM_SPEC_TOKENS=2
                 ;;
             gemma4:26b-mtp)
                 TARGET_REPO="google/gemma-4-26B-A4B-it"
                 DRAFT_REPO="google/gemma-4-26B-A4B-it-assistant"
-                NUM_SPEC_TOKENS=4
                 ;;
             gemma4:31b-mtp)
                 TARGET_REPO="google/gemma-4-31B-it"
                 DRAFT_REPO="google/gemma-4-31B-it-assistant"
-                NUM_SPEC_TOKENS=4
-                ;;
-            *)
-                echo "[init] unrecognised MTP model tag: ${MODEL}" >&2
-                kill "${SERVE_PID}" 2>/dev/null || true
-                exit 1
                 ;;
         esac
 
@@ -110,10 +114,9 @@ case "${MODEL}" in
                 --local-dir-use-symlinks False
             # Modelfile is intentionally minimal:
             #   * `PARAMETER num_speculative_tokens` is not in 0.23.2's
-            #     allowlist ("unknown parameter") — NUM_SPEC_TOKENS is
-            #     kept above as documentation of the recommended value
-            #     per variant, ready to re-wire once upstream surfaces
-            #     the knob.
+            #     allowlist ("unknown parameter") — the recommended
+            #     per-variant values are kept in the case-block comment
+            #     above, ready to re-wire once upstream surfaces the knob.
             #   * No `--quantize` on `ollama create` because that path
             #     requires MLX (Apple Silicon only); on Linux/CUDA the
             #     model lands as native BF16.

--- a/llm/init.sh
+++ b/llm/init.sh
@@ -39,10 +39,25 @@ done
 # Model-name convention: `gemma4:<variant>-mtp` triggers the MTP build
 # path. Anything else falls through to plain `ollama pull`.
 #
-# MTP needs target + drafter safetensors (not GGUF) because PR #15980
-# only wires the DRAFT directive through Ollama's safetensors import
-# path. The variants below mirror Google's HF org layout
-# (https://huggingface.co/google).
+# Layout: both target and drafter are downloaded from Hugging Face as
+# safetensors. `ollama create --experimental` only accepts safetensors
+# directories under `FROM` (the GGUF-tag-as-FROM fallback was tested
+# and rejected with "not a supported model directory"). On Linux/CUDA
+# the `--quantize` flag also requires MLX (Apple Silicon), so the
+# import lands as native BF16.
+#
+# VRAM footprint (measured / HF):
+#   E2B BF16 ~10 GiB on disk → ~13-14 GiB at inference (weights + Q8
+#                              KV cache @ 32k + activations). Tight
+#                              but feasible on a 16 GiB consumer GPU;
+#                              drop OLLAMA_CONTEXT_LENGTH to 8k/4k
+#                              if it OOMs at warm-up.
+#   E4B BF16 ~22 GiB on disk → ~28 GiB at inference. Needs 32 GiB+ GPU.
+#   26B / 31B → datacenter cards only.
+#
+# Pre-quantised gemma4 MTP tags in the Ollama library (e.g. the
+# existing `gemma4:31b-coding-mtp-bf16`) will eventually obviate
+# this whole branch; until then this is the only way on Linux.
 case "${MODEL}" in
     *-mtp|*-mtp-*)
         case "${MODEL}" in
@@ -93,39 +108,21 @@ case "${MODEL}" in
             HF_TOKEN="${HF_TOKEN}" huggingface-cli download "${DRAFT_REPO}" \
                 --local-dir "${BUILD_DIR}/draft" \
                 --local-dir-use-symlinks False
-            # Modelfile is intentionally minimal: PARAMETER
-            # `num_speculative_tokens` is not in 0.23.2's allowlist
-            # ("unknown parameter") even though the PR conversation
-            # mentioned it. Letting Ollama use its default count is
-            # fine for now; revisit when the upstream surfaces the
-            # knob (env var or per-request option). NUM_SPEC_TOKENS
-            # is kept above as documentation of the recommended
-            # value per variant.
+            # Modelfile is intentionally minimal:
+            #   * `PARAMETER num_speculative_tokens` is not in 0.23.2's
+            #     allowlist ("unknown parameter") — NUM_SPEC_TOKENS is
+            #     kept above as documentation of the recommended value
+            #     per variant, ready to re-wire once upstream surfaces
+            #     the knob.
+            #   * No `--quantize` on `ollama create` because that path
+            #     requires MLX (Apple Silicon only); on Linux/CUDA the
+            #     model lands as native BF16.
             cat > "${BUILD_DIR}/Modelfile" <<EOF
 FROM ${BUILD_DIR}/target
 DRAFT ${BUILD_DIR}/draft
 EOF
-            # Quantize at import time. The PR conversation noted that
-            # unquantized BF16 has the best output quality but the
-            # target weights alone (~14 GiB for E4B BF16) plus KV
-            # cache + activations push past 16 GiB on a 4090 Laptop.
-            # q8_0 halves the model size at near-lossless quality and
-            # leaves headroom for the 32 k context KV cache. Override
-            # with `MTP_QUANTIZE=` (empty) to keep BF16 on a card with
-            # ≥ 24 GiB, or with e.g. `q4_K_M` for tighter memory at
-            # some quality cost.
-            # Ollama 0.23.2 only exposes `--quantize` (applies to the
-            # target model). `--quantize-draft` was mentioned in the
-            # PR thread but isn't on the CLI yet — the drafter stays
-            # at its native dtype, which is fine because it's tiny
-            # (the 4-layer assistant is a few hundred MB regardless).
-            QUANTIZE="${MTP_QUANTIZE-q8_0}"
-            QUANTIZE_FLAGS=()
-            if [ -n "${QUANTIZE}" ]; then
-                QUANTIZE_FLAGS+=(--quantize "${QUANTIZE}")
-            fi
-            echo "[init] ollama create --experimental ${MODEL} (quantize=${QUANTIZE:-bf16})"
-            ollama create --experimental "${MODEL}" -f "${BUILD_DIR}/Modelfile" "${QUANTIZE_FLAGS[@]}"
+            echo "[init] ollama create --experimental ${MODEL} (native BF16)"
+            ollama create --experimental "${MODEL}" -f "${BUILD_DIR}/Modelfile"
             # Cleanup: ollama create copied the weights into its own
             # blob store under /root/.ollama; the staging dir is no
             # longer needed and would otherwise waste ~10 GB per build.

--- a/llm/init.sh
+++ b/llm/init.sh
@@ -93,10 +93,17 @@ case "${MODEL}" in
             HF_TOKEN="${HF_TOKEN}" huggingface-cli download "${DRAFT_REPO}" \
                 --local-dir "${BUILD_DIR}/draft" \
                 --local-dir-use-symlinks False
+            # Modelfile is intentionally minimal: PARAMETER
+            # `num_speculative_tokens` is not in 0.23.2's allowlist
+            # ("unknown parameter") even though the PR conversation
+            # mentioned it. Letting Ollama use its default count is
+            # fine for now; revisit when the upstream surfaces the
+            # knob (env var or per-request option). NUM_SPEC_TOKENS
+            # is kept above as documentation of the recommended
+            # value per variant.
             cat > "${BUILD_DIR}/Modelfile" <<EOF
 FROM ${BUILD_DIR}/target
 DRAFT ${BUILD_DIR}/draft
-PARAMETER num_speculative_tokens ${NUM_SPEC_TOKENS}
 EOF
             echo "[init] ollama create --experimental ${MODEL}"
             ollama create --experimental "${MODEL}" -f "${BUILD_DIR}/Modelfile"

--- a/llm/init.sh
+++ b/llm/init.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Start `ollama serve` in the background, wait for the API to accept
-# requests, then pull ${LLM_MODEL} so the first /api/chat against this
-# container doesn't 404. Hand PID back to `ollama serve` via `wait` so
-# SIGTERM propagates cleanly at container stop.
+# requests, then make ${LLM_MODEL} available (either via `ollama pull`
+# for library tags, or via `ollama create` from Hugging Face
+# safetensors for the MTP variants). Hand PID back to `ollama serve`
+# via `wait` so SIGTERM propagates cleanly at container stop.
 #
 # Idempotent w.r.t. the model cache: if the model is already present in
-# the mounted volume, `ollama pull` is a no-op and the API is serving
+# the mounted volume, both paths short-circuit and the API is serving
 # within ~2 s.
 set -euo pipefail
 
@@ -35,9 +36,83 @@ for i in $(seq 1 60); do
     sleep 1
 done
 
-echo "[init] pulling model: ${MODEL}"
-ollama pull "${MODEL}"
-echo "[init] model ready: ${MODEL}"
+# Model-name convention: `gemma4:<variant>-mtp` triggers the MTP build
+# path. Anything else falls through to plain `ollama pull`.
+#
+# MTP needs target + drafter safetensors (not GGUF) because PR #15980
+# only wires the DRAFT directive through Ollama's safetensors import
+# path. The variants below mirror Google's HF org layout
+# (https://huggingface.co/google).
+case "${MODEL}" in
+    *-mtp|*-mtp-*)
+        case "${MODEL}" in
+            gemma4:e4b-mtp)
+                TARGET_REPO="google/gemma-4-E4B-it"
+                DRAFT_REPO="google/gemma-4-E4B-it-assistant"
+                NUM_SPEC_TOKENS=4
+                ;;
+            gemma4:e2b-mtp)
+                TARGET_REPO="google/gemma-4-E2B-it"
+                DRAFT_REPO="google/gemma-4-E2B-it-assistant"
+                NUM_SPEC_TOKENS=2
+                ;;
+            gemma4:26b-mtp)
+                TARGET_REPO="google/gemma-4-26B-A4B-it"
+                DRAFT_REPO="google/gemma-4-26B-A4B-it-assistant"
+                NUM_SPEC_TOKENS=4
+                ;;
+            gemma4:31b-mtp)
+                TARGET_REPO="google/gemma-4-31B-it"
+                DRAFT_REPO="google/gemma-4-31B-it-assistant"
+                NUM_SPEC_TOKENS=4
+                ;;
+            *)
+                echo "[init] unrecognised MTP model tag: ${MODEL}" >&2
+                kill "${SERVE_PID}" 2>/dev/null || true
+                exit 1
+                ;;
+        esac
+
+        # Skip the build if `ollama list` already shows the tag — keeps
+        # `docker compose restart` snappy after the first cold create.
+        if ollama list 2>/dev/null | awk '{print $1}' | grep -Fxq "${MODEL}"; then
+            echo "[init] MTP model already present: ${MODEL}"
+        else
+            if [ -z "${HF_TOKEN:-}" ]; then
+                echo "[init] HF_TOKEN is required to build ${MODEL} (target + drafter are gated Gemma models on HF)" >&2
+                kill "${SERVE_PID}" 2>/dev/null || true
+                exit 1
+            fi
+            BUILD_DIR="/tmp/mtp-build-$$"
+            mkdir -p "${BUILD_DIR}/target" "${BUILD_DIR}/draft"
+            echo "[init] downloading target ${TARGET_REPO}"
+            HF_TOKEN="${HF_TOKEN}" huggingface-cli download "${TARGET_REPO}" \
+                --local-dir "${BUILD_DIR}/target" \
+                --local-dir-use-symlinks False
+            echo "[init] downloading drafter ${DRAFT_REPO}"
+            HF_TOKEN="${HF_TOKEN}" huggingface-cli download "${DRAFT_REPO}" \
+                --local-dir "${BUILD_DIR}/draft" \
+                --local-dir-use-symlinks False
+            cat > "${BUILD_DIR}/Modelfile" <<EOF
+FROM ${BUILD_DIR}/target
+DRAFT ${BUILD_DIR}/draft
+PARAMETER num_speculative_tokens ${NUM_SPEC_TOKENS}
+EOF
+            echo "[init] ollama create --experimental ${MODEL}"
+            ollama create --experimental "${MODEL}" -f "${BUILD_DIR}/Modelfile"
+            # Cleanup: ollama create copied the weights into its own
+            # blob store under /root/.ollama; the staging dir is no
+            # longer needed and would otherwise waste ~10 GB per build.
+            rm -rf "${BUILD_DIR}"
+            echo "[init] MTP model ready: ${MODEL}"
+        fi
+        ;;
+    *)
+        echo "[init] pulling model: ${MODEL}"
+        ollama pull "${MODEL}"
+        echo "[init] model ready: ${MODEL}"
+        ;;
+esac
 
 # Warm the model into VRAM so the first /api/chat from the
 # orchestrator doesn't pay a 5–15 s cold-load tax (model load shows up

--- a/orchestrator/config.example.toml
+++ b/orchestrator/config.example.toml
@@ -44,8 +44,10 @@ url = "http://tts-streamer:7070/speak"
 # `/append` (api②) — POSTed for the second and later sentences of
 # the same turn. Doesn't cancel or reset; reuses whatever burst
 # budget remains so back-to-back sentences don't re-prebuffer 5 s
-# each and overflow audio-io's ring (issue #16). Empty falls back
-# to `url` for every sentence.
+# each and overflow audio-io's ring (issue #16). Required when
+# `url` is set — the streamer's `/speak` now FIFO-aborts the
+# previous task, so a fallback through `/speak` would cut sentence
+# N mid-utterance when sentence N+1 arrives.
 append_url = "http://tts-streamer:7070/append"
 # Cancel-in-flight URL. Used by `wake.barge_in` to interrupt a
 # TTS reply when the operator says the wake word again. Empty

--- a/orchestrator/config.example.toml
+++ b/orchestrator/config.example.toml
@@ -37,7 +37,16 @@ max_inflight = 1
 # logged but not voiced. Production wires this at the `tts-streamer`
 # service which fronts VOICEVOX + the audio-io /spk push.
 [tts]
+# `/speak` (api①) — POSTed for the first sentence of each turn.
+# Cancels any in-flight utterance, drops audio-io's ring, and starts
+# fresh with a full 5 s burst budget.
 url = "http://tts-streamer:7070/speak"
+# `/append` (api②) — POSTed for the second and later sentences of
+# the same turn. Doesn't cancel or reset; reuses whatever burst
+# budget remains so back-to-back sentences don't re-prebuffer 5 s
+# each and overflow audio-io's ring (issue #16). Empty falls back
+# to `url` for every sentence.
+append_url = "http://tts-streamer:7070/append"
 # Cancel-in-flight URL. Used by `wake.barge_in` to interrupt a
 # TTS reply when the operator says the wake word again. Empty
 # disables the cancel side-effect.

--- a/orchestrator/src/config.rs
+++ b/orchestrator/src/config.rs
@@ -111,8 +111,11 @@ pub struct TtsConfig {
     /// doesn't cancel or reset, just consumes whatever burst budget
     /// is left after realtime drain — preventing the audio-io ring
     /// overflow that issue #16 describes (re-bursting 5 s every
-    /// sentence caused dropouts). Empty falls back to using `url`
-    /// for every sentence (matches pre-#16 behaviour).
+    /// sentence caused dropouts). Required when `url` is set; the
+    /// pre-#16 fallback (route every sentence through `/speak`) is
+    /// no longer equivalent because the streamer's `/speak` now
+    /// FIFO-aborts the previous task, so a fallback would cut
+    /// sentence N mid-stream when sentence N+1 arrives.
     pub append_url: String,
     /// `tts-streamer` `/stop` URL. Used for barge-in (`wake.barge_in`)
     /// — orchestrator POSTs here when a new WakeWordDetected arrives
@@ -334,6 +337,17 @@ impl Config {
             if self.tts.max_inflight == 0 {
                 anyhow::bail!("tts.max_inflight must be >= 1 when url is set");
             }
+            // append_url は issue #16 の本丸。空フォールバックを許すと
+            // 全文が /speak に流れ、streamer 側の FIFO abort が文 N を
+            // 文 N+1 で中断してしまう（pre-#16 と等価ではない）。url を
+            // 設定する以上 append_url も必須にする。
+            if self.tts.append_url.is_empty() {
+                anyhow::bail!(
+                    "tts.append_url must be set when tts.url is set \
+                     (issue #16: /append routes continuation sentences so /speak's \
+                     FIFO-abort doesn't cut mid-utterance)"
+                );
+            }
         }
         if self.wake.required {
             if self.wake.wake_window_ms == 0 {
@@ -437,6 +451,20 @@ mod tests {
         cfg.tts.url = "http://tts:7070/speak".into();
         cfg.tts.stop_url = "http://tts:7070/stop".into();
         cfg.wake.barge_in = true;
+        cfg.tts.append_url = "http://tts:7070/append".into();
         cfg.validate().expect("barge_in + stop_url is valid");
+    }
+
+    #[test]
+    fn tts_url_without_append_url_is_rejected() {
+        // issue #16 の追補: url を入れた以上 append_url も必須。空のままだと
+        // pipeline.rs が全文を /speak に流し、streamer の FIFO-abort が
+        // 文 N+1 で文 N を中断してしまう。
+        let mut cfg = Config::default();
+        cfg.tts.url = "http://tts:7070/speak".into();
+        cfg.tts.append_url = String::new();
+        let err = cfg.validate().expect_err("should reject url without append_url");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("append_url"), "unexpected error: {msg}");
     }
 }

--- a/orchestrator/src/config.rs
+++ b/orchestrator/src/config.rs
@@ -427,6 +427,7 @@ mod tests {
         // permit.
         let mut cfg = Config::default();
         cfg.tts.url = "http://tts:7070/speak".into();
+        cfg.tts.append_url = "http://tts:7070/append".into();
         cfg.tts.stop_url = String::new();
         cfg.wake.barge_in = true;
         let err = cfg.validate().expect_err("should reject barge_in without stop_url");

--- a/orchestrator/src/config.rs
+++ b/orchestrator/src/config.rs
@@ -101,8 +101,19 @@ pub struct LlmConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct TtsConfig {
-    /// `tts-streamer` `/speak` URL. Empty disables the stage.
+    /// `tts-streamer` `/speak` URL. Empty disables the stage. POSTed
+    /// for the **first** sentence of each turn — `/speak` is api①: it
+    /// cancels any in-flight utterance, drops audio-io's ring, and
+    /// starts the new audio with a full 5 s burst budget.
     pub url: String,
+    /// `tts-streamer` `/append` URL. POSTed for the **second and
+    /// later** sentences of the same turn. `/append` is api②: it
+    /// doesn't cancel or reset, just consumes whatever burst budget
+    /// is left after realtime drain — preventing the audio-io ring
+    /// overflow that issue #16 describes (re-bursting 5 s every
+    /// sentence caused dropouts). Empty falls back to using `url`
+    /// for every sentence (matches pre-#16 behaviour).
+    pub append_url: String,
     /// `tts-streamer` `/stop` URL. Used for barge-in (`wake.barge_in`)
     /// — orchestrator POSTs here when a new WakeWordDetected arrives
     /// while a previous turn's TTS is still streaming. Empty disables
@@ -245,6 +256,7 @@ impl Default for TtsConfig {
             // this; dev / CI runs without `tts-streamer` leave it empty
             // so the pipeline still completes without trying to speak.
             url: String::new(),
+            append_url: String::new(),
             stop_url: String::new(),
             finalize_url: String::new(),
             timeout_ms: 60_000,

--- a/orchestrator/src/main.rs
+++ b/orchestrator/src/main.rs
@@ -46,6 +46,14 @@ struct Args {
     #[arg(long, env = "ORCH_TTS_URL")]
     tts_url: Option<String>,
 
+    /// Override `tts.append_url`. POSTed for continuation sentences
+    /// within a turn (issue #16 — `/append` reuses the streamer's
+    /// burst budget instead of re-prebuffering 5 s every sentence,
+    /// which used to overflow audio-io's ring). Empty falls back to
+    /// `tts.url` for every sentence.
+    #[arg(long, env = "ORCH_TTS_APPEND_URL")]
+    tts_append_url: Option<String>,
+
     /// Override `tts.stop_url`. Empty disables barge-in TTS cancel.
     #[arg(long, env = "ORCH_TTS_STOP_URL")]
     tts_stop_url: Option<String>,
@@ -132,6 +140,9 @@ async fn main() -> Result<()> {
     }
     if let Some(v) = args.tts_url {
         config.tts.url = v;
+    }
+    if let Some(v) = args.tts_append_url {
+        config.tts.append_url = v;
     }
     if let Some(v) = args.tts_stop_url {
         config.tts.stop_url = v;

--- a/orchestrator/src/pipeline.rs
+++ b/orchestrator/src/pipeline.rs
@@ -381,9 +381,9 @@ pub async fn run_turn(
 /// The first sentence of each turn goes to `tts.url` (`/speak` =
 /// api①, resets the burst budget on the streamer); subsequent
 /// sentences go to `tts.append_url` (`/append` = api②, reuses the
-/// budget). When `append_url` is empty we fall back to `url` for
-/// every sentence — pre-issue-#16 behaviour, kept so old deployments
-/// don't break before the streamer is updated.
+/// budget). `append_url` is validated as required at startup when
+/// `url` is set (see `Config::validate`), so we can dispatch
+/// continuation sentences unconditionally to it here.
 fn spawn_tts_consumer(
     backends: Arc<Backends>,
     wake: Arc<WakeMachine>,
@@ -405,9 +405,10 @@ fn spawn_tts_consumer(
                 continue;
             }
             // First sentence per turn → /speak (api①, resets budget).
-            // Subsequent sentences → /append (api②) if configured,
-            // else fall back to /speak.
-            let (api_label, target_url) = if is_first || backends.tts.append_url.is_empty() {
+            // Subsequent sentences → /append (api②). append_url is
+            // required at startup when url is set, so the second
+            // branch is always wired.
+            let (api_label, target_url) = if is_first {
                 ("speak", &backends.tts.url)
             } else {
                 ("append", &backends.tts.append_url)
@@ -422,8 +423,8 @@ fn spawn_tts_consumer(
 /// Inner POST. Permit management is the caller's responsibility — see
 /// `spawn_tts_consumer` (per-turn permit) for the streaming path.
 /// `api` is "speak" or "append" (set by the consumer based on
-/// is_first/append_url); it's only used for log clarity — the actual
-/// dispatch is by `url`.
+/// is_first); it's only used for log clarity — the actual dispatch
+/// is by `url`.
 async fn tts_speak_inner(backends: &Backends, api: &str, url: &str, text: &str) {
     info!(
         target: "orch::pipeline",

--- a/orchestrator/src/pipeline.rs
+++ b/orchestrator/src/pipeline.rs
@@ -407,12 +407,12 @@ fn spawn_tts_consumer(
             // First sentence per turn → /speak (api①, resets budget).
             // Subsequent sentences → /append (api②) if configured,
             // else fall back to /speak.
-            let target_url = if is_first || backends.tts.append_url.is_empty() {
-                &backends.tts.url
+            let (api_label, target_url) = if is_first || backends.tts.append_url.is_empty() {
+                ("speak", &backends.tts.url)
             } else {
-                &backends.tts.append_url
+                ("append", &backends.tts.append_url)
             };
-            tts_speak_inner(&backends, target_url, &sentence).await;
+            tts_speak_inner(&backends, api_label, target_url, &sentence).await;
             is_first = false;
         }
         drop(permit);
@@ -421,8 +421,18 @@ fn spawn_tts_consumer(
 
 /// Inner POST. Permit management is the caller's responsibility — see
 /// `spawn_tts_consumer` (per-turn permit) for the streaming path.
-/// `url` selects between `/speak` and `/append` (see consumer).
-async fn tts_speak_inner(backends: &Backends, url: &str, text: &str) {
+/// `api` is "speak" or "append" (set by the consumer based on
+/// is_first/append_url); it's only used for log clarity — the actual
+/// dispatch is by `url`.
+async fn tts_speak_inner(backends: &Backends, api: &str, url: &str, text: &str) {
+    info!(
+        target: "orch::pipeline",
+        api,
+        url,
+        chars = text.chars().count(),
+        "TTS POST: {:?}",
+        text.chars().take(40).collect::<String>()
+    );
     let body = json!({ "text": text });
     let res = backends
         .http
@@ -440,18 +450,19 @@ async fn tts_speak_inner(backends: &Backends, url: &str, text: &str) {
             // so it doesn't pollute production logs every time the
             // user interrupts the assistant.
             if status.is_success() || status.as_u16() == 499 {
-                info!(target: "orch::pipeline", "TTS ok ({status})");
+                info!(target: "orch::pipeline", api, "TTS ok ({status})");
             } else {
                 let body = resp.text().await.unwrap_or_default();
                 warn!(
                     target: "orch::pipeline",
+                    api,
                     "TTS responded {}: {}",
                     status,
                     body.chars().take(200).collect::<String>()
                 );
             }
         }
-        Err(e) => warn!(target: "orch::pipeline", "TTS POST failed: {e:#}"),
+        Err(e) => warn!(target: "orch::pipeline", api, "TTS POST failed: {e:#}"),
     }
 }
 

--- a/orchestrator/src/pipeline.rs
+++ b/orchestrator/src/pipeline.rs
@@ -377,6 +377,13 @@ pub async fn run_turn(
 /// TTS consumer task: drains the sentence channel, calling
 /// `tts_speak_inner` serially per sentence while the turn is still
 /// active. Holds the turn-level TTS permit until the channel closes.
+///
+/// The first sentence of each turn goes to `tts.url` (`/speak` =
+/// api①, resets the burst budget on the streamer); subsequent
+/// sentences go to `tts.append_url` (`/append` = api②, reuses the
+/// budget). When `append_url` is empty we fall back to `url` for
+/// every sentence — pre-issue-#16 behaviour, kept so old deployments
+/// don't break before the streamer is updated.
 fn spawn_tts_consumer(
     backends: Arc<Backends>,
     wake: Arc<WakeMachine>,
@@ -384,6 +391,7 @@ fn spawn_tts_consumer(
     permit: Option<tokio::sync::OwnedSemaphorePermit>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
+        let mut is_first = true;
         while let Some(sentence) = rx.recv().await {
             // Drain the rest after barge-in so the LLM sender can
             // finish without blocking, but skip the actual /speak.
@@ -396,19 +404,29 @@ fn spawn_tts_consumer(
             if permit.is_none() || backends.tts.url.is_empty() || sentence.is_empty() {
                 continue;
             }
-            tts_speak_inner(&backends, &sentence).await;
+            // First sentence per turn → /speak (api①, resets budget).
+            // Subsequent sentences → /append (api②) if configured,
+            // else fall back to /speak.
+            let target_url = if is_first || backends.tts.append_url.is_empty() {
+                &backends.tts.url
+            } else {
+                &backends.tts.append_url
+            };
+            tts_speak_inner(&backends, target_url, &sentence).await;
+            is_first = false;
         }
         drop(permit);
     })
 }
 
-/// Inner /speak POST. Permit management is the caller's responsibility
-/// — see `spawn_tts_consumer` (per-turn permit) for the streaming path.
-async fn tts_speak_inner(backends: &Backends, text: &str) {
+/// Inner POST. Permit management is the caller's responsibility — see
+/// `spawn_tts_consumer` (per-turn permit) for the streaming path.
+/// `url` selects between `/speak` and `/append` (see consumer).
+async fn tts_speak_inner(backends: &Backends, url: &str, text: &str) {
     let body = json!({ "text": text });
     let res = backends
         .http
-        .post(&backends.tts.url)
+        .post(url)
         .json(&body)
         .timeout(std::time::Duration::from_millis(backends.tts.timeout_ms))
         .send()

--- a/text-to-speech/streamer/src/main.rs
+++ b/text-to-speech/streamer/src/main.rs
@@ -359,7 +359,7 @@ async fn enter_speak(state: AppState, text: String, mode: ApiMode) -> Response {
     // Append doesn't cancel or reset — the previous task (if any) will
     // complete naturally, and speak_permit serialises us behind it.
 
-    let task = tokio::spawn(speak_one(state.clone(), text, mode));
+    let task = tokio::spawn(speak_one(state.clone(), text));
     let abort = task.abort_handle();
     {
         // Store our abort handle so a subsequent /speak can cancel us.
@@ -470,7 +470,7 @@ async fn stop(State(state): State<AppState>) -> Json<Value> {
 
 // --- core flow -----------------------------------------------------
 
-async fn speak_one(state: AppState, text: String, mode: ApiMode) -> Result<Value> {
+async fn speak_one(state: AppState, text: String) -> Result<Value> {
     // Serialise speak_one regardless of which caller spawned us. The
     // /speak handler aborts the previous task before spawning a new
     // one, but abort only takes effect at .await boundaries — a task
@@ -502,30 +502,15 @@ async fn speak_one(state: AppState, text: String, mode: ApiMode) -> Result<Value
         "synthesized"
     );
 
-    // POST /start only at the start of a turn (api①). audio-io's
-    // /start currently rebuilds the cpal stream + ring buffer from
-    // scratch, so calling it before every /append used to drop the
-    // tail of the previous sentence (the ~200 ms between /start
-    // returning and the next WS frame arriving would be filled with
-    // cpal silence — manifesting as the "聞こえるよ" head-clipped
-    // playback). /append assumes audio-io is already running because
-    // /speak just brought it up.
-    if mode == ApiMode::Speak {
-        if let Some(base) = state.cfg.audio_io_base.as_deref() {
-            let t = Instant::now();
-            match state
-                .http
-                .post(format!("{}/start", base))
-                .timeout(Duration::from_secs(5))
-                .send()
-                .await
-            {
-                Ok(_) => {}
-                Err(e) => warn!("POST /start failed ({}); continuing", e),
-            }
-            info!(elapsed_ms = t.elapsed().as_millis() as u64, "POST /start done");
-        }
-    }
+    // We deliberately do NOT POST /start here. audio-io's /start is
+    // currently a destructive "restart" (drops the existing cpal
+    // stream + ring buffer and rebuilds), so calling it before every
+    // utterance produced a ~200 ms silence head-clip on the audio
+    // ("聞こえるよ" / "どういたしまして" started mid-word). audio-io
+    // is expected to be running already via `autostart = true` in
+    // its config; if it isn't, the /spk WS below will fail loud and
+    // the operator can /start manually. See compose.yaml audio-io
+    // service.
 
     // The /speak handler bails out before spawn if spk_url is None, so
     // this should always be Some here. Surface a clean error rather

--- a/text-to-speech/streamer/src/main.rs
+++ b/text-to-speech/streamer/src/main.rs
@@ -330,29 +330,47 @@ async fn enter_speak(state: AppState, text: String, mode: ApiMode) -> Response {
         // Barge-in: tear down the in-flight task and the audio already
         // queued in audio-io's ring, then reset the burst budget so
         // the new utterance starts from a full 5 s headroom.
+        //
+        // current_task may hold the AbortHandle of a task that has
+        // already completed normally (we don't proactively clear it
+        // when speak_one returns). Calling /spk/stop on that branch
+        // sets audio-io's flush flag, and the *new* utterance's
+        // first Frame then gets eaten by the cancellation path in
+        // playback_producer_task — manifesting as the head of the
+        // 2nd-turn 1st sentence being clipped to ~500 ms of silence
+        // (the "うん" → "ん" head-clip seen in production). Guard
+        // with is_finished() so /spk/stop only fires on a real
+        // barge-in (previous task still running).
         let prev_abort = {
             let mut guard = state.current_task.lock().await;
             guard.take()
         };
         if let Some(prev) = prev_abort {
-            prev.abort();
-            // Drop already-buffered playback. The abort above stops
-            // further frames from being WS-pushed, but audio-io still
-            // has up to playback_buffer_ms of ring on the speaker —
-            // without /spk/stop the user keeps hearing the cancelled
-            // utterance for up to 10 s (fixes PR #15 review #27).
-            if let Some(base) = state.cfg.audio_io_base.as_deref() {
-                match state
-                    .http
-                    .post(format!("{}/spk/stop", base))
-                    .timeout(Duration::from_secs(2))
-                    .send()
-                    .await
-                {
-                    Ok(_) => {}
-                    Err(e) => warn!("POST /spk/stop after barge-in failed: {}", e),
+            if !prev.is_finished() {
+                prev.abort();
+                // Drop already-buffered playback. The abort above stops
+                // further frames from being WS-pushed, but audio-io
+                // still has up to playback_buffer_ms of ring on the
+                // speaker — without /spk/stop the user keeps hearing
+                // the cancelled utterance for up to 10 s (fixes
+                // PR #15 review #27).
+                if let Some(base) = state.cfg.audio_io_base.as_deref() {
+                    match state
+                        .http
+                        .post(format!("{}/spk/stop", base))
+                        .timeout(Duration::from_secs(2))
+                        .send()
+                        .await
+                    {
+                        Ok(_) => {}
+                        Err(e) => warn!("POST /spk/stop after barge-in failed: {}", e),
+                    }
                 }
             }
+            // Else: previous task already finished, the stored
+            // AbortHandle is just a stale reference — drop it without
+            // touching audio-io. The new task's Frames will land in a
+            // clean ring with no flush flag racing them.
         }
         state.burst_budget.lock().await.reset();
     }

--- a/text-to-speech/streamer/src/main.rs
+++ b/text-to-speech/streamer/src/main.rs
@@ -359,7 +359,7 @@ async fn enter_speak(state: AppState, text: String, mode: ApiMode) -> Response {
     // Append doesn't cancel or reset — the previous task (if any) will
     // complete naturally, and speak_permit serialises us behind it.
 
-    let task = tokio::spawn(speak_one(state.clone(), text));
+    let task = tokio::spawn(speak_one(state.clone(), text, mode));
     let abort = task.abort_handle();
     {
         // Store our abort handle so a subsequent /speak can cancel us.
@@ -470,7 +470,7 @@ async fn stop(State(state): State<AppState>) -> Json<Value> {
 
 // --- core flow -----------------------------------------------------
 
-async fn speak_one(state: AppState, text: String) -> Result<Value> {
+async fn speak_one(state: AppState, text: String, mode: ApiMode) -> Result<Value> {
     // Serialise speak_one regardless of which caller spawned us. The
     // /speak handler aborts the previous task before spawning a new
     // one, but abort only takes effect at .await boundaries — a task
@@ -502,22 +502,29 @@ async fn speak_one(state: AppState, text: String) -> Result<Value> {
         "synthesized"
     );
 
-    // Idempotent /start so the playback pipeline is up before the WS
-    // write. Failures here are non-fatal — older audio-io builds
-    // without /start still accept frames.
-    if let Some(base) = state.cfg.audio_io_base.as_deref() {
-        let t = Instant::now();
-        match state
-            .http
-            .post(format!("{}/start", base))
-            .timeout(Duration::from_secs(5))
-            .send()
-            .await
-        {
-            Ok(_) => {}
-            Err(e) => warn!("POST /start failed ({}); continuing", e),
+    // POST /start only at the start of a turn (api①). audio-io's
+    // /start currently rebuilds the cpal stream + ring buffer from
+    // scratch, so calling it before every /append used to drop the
+    // tail of the previous sentence (the ~200 ms between /start
+    // returning and the next WS frame arriving would be filled with
+    // cpal silence — manifesting as the "聞こえるよ" head-clipped
+    // playback). /append assumes audio-io is already running because
+    // /speak just brought it up.
+    if mode == ApiMode::Speak {
+        if let Some(base) = state.cfg.audio_io_base.as_deref() {
+            let t = Instant::now();
+            match state
+                .http
+                .post(format!("{}/start", base))
+                .timeout(Duration::from_secs(5))
+                .send()
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => warn!("POST /start failed ({}); continuing", e),
+            }
+            info!(elapsed_ms = t.elapsed().as_millis() as u64, "POST /start done");
         }
-        info!(elapsed_ms = t.elapsed().as_millis() as u64, "POST /start done");
     }
 
     // The /speak handler bails out before spawn if spk_url is None, so

--- a/text-to-speech/streamer/src/main.rs
+++ b/text-to-speech/streamer/src/main.rs
@@ -1,19 +1,35 @@
 //! tts-streamer: HTTP shim that turns a text request into VOICEVOX
 //! synthesis + audio-io playback streaming.
 //!
-//! Endpoints (compatible 1:1 with the prior Python implementation):
-//!     POST /speak    body: {"text": "..."}     → streams to SPK_URL
-//!     POST /finalize                            → drain handshake
-//!     POST /stop                                → cancel + drop
-//!     GET  /health                              → 200 once boot finishes
+//! Endpoints:
+//!     POST /speak    body: {"text": "..."}   start of turn / barge-in
+//!     POST /append   body: {"text": "..."}   continuation within the turn
+//!     POST /finalize                         drain handshake
+//!     POST /stop                             cancel + drop ring
+//!     GET  /health                           200 once boot finishes
 //!
-//! Concurrency: "newest wins" — at most one /speak runs at a time, and
-//! a fresh /speak aborts the in-flight one before starting. The
-//! cancelled task surfaces as 499 Client Closed Request so the caller
-//! can distinguish "interrupted" from synth/network errors. The
-//! orchestrator's per-turn TTS permit normally prevents overlapping
-//! /speak in the no-barge-in path, so this cancel-on-overlap mostly
-//! fires during /stop or barge-in.
+//! Two-endpoint design (issue #16):
+//!   * `/speak` is api①: forcibly cancels any in-flight task, POSTs
+//!     `/spk/stop` to drop audio-io's playback ring, **resets** the
+//!     burst budget, then synthesises and pushes the new utterance.
+//!   * `/append` is api②: does NOT cancel or reset, but pulls from the
+//!     remaining burst budget so a turn's later sentences land in the
+//!     ring without re-bursting the full prebuffer (the old single-
+//!     `/speak` behaviour overflowed the ring on every continuation,
+//!     causing audible glitches).
+//!
+//! Burst budget (BurstBudget): a per-process token-bucket-style estimate
+//! of how many seconds of audio audio-io still has queued. capacity = 5 s
+//! (matches the prebuffer that the old code unconditionally bursted).
+//! `/speak` resets it; `/append` consumes from whatever is left after
+//! realtime drain. See `BurstBudget` below.
+//!
+//! Concurrency: at most one synthesise→push pipeline runs at a time,
+//! enforced by `speak_permit` (single-permit Semaphore). `/speak`
+//! additionally aborts the in-flight task before queueing its own (so a
+//! barge-in cuts mid-utterance); `/append` just queues. A cancelled
+//! task surfaces as 499 Client Closed Request so the caller can
+//! distinguish "interrupted" from synth/network errors.
 
 use std::env;
 use std::net::SocketAddr;
@@ -110,9 +126,94 @@ struct AppState {
     // network resolves. The semaphore makes the new request wait for
     // the previous one's permit to drop, preventing two
     // synthesize→ws-push pipelines from overlapping on VOICEVOX and
-    // /spk.
+    // /spk. `/append` shares this semaphore, so a continuation queues
+    // behind an in-flight `/speak` rather than racing onto the WS.
     speak_permit: Arc<Semaphore>,
+    // Shared burst budget (issue #16). Tracks how much room is left in
+    // audio-io's ring for a "send-as-fast-as-possible" burst before we
+    // must pace at realtime. Reset by `/speak`; consumed by both
+    // `/speak` and `/append`. See `BurstBudget` below.
+    burst_budget: Arc<Mutex<BurstBudget>>,
 }
+
+/// Token-bucket-style accounting for audio-io's playback ring depth.
+///
+/// audio-io has a 10 s playback buffer (`playback_buffer_ms` default).
+/// We keep the **first** 5 s of an utterance arriving as a burst (so
+/// audio starts immediately without WS round-trip jitter), then pace
+/// the rest at realtime. The same 5 s budget is shared across `/speak`
+/// + `/append` within a turn: once it's spent, the next call can only
+/// pace (no burst), preventing the buffer overflow that caused the
+/// audible glitches before issue #16.
+///
+/// Model: `depth_s` is the ring depth at `at`. Without further sends,
+/// audio-io drains at realtime so the depth decays by `now - at`
+/// seconds. A burst of S seconds at time t becomes `depth_at_t + S`
+/// queued, drained from t onwards. A paced span maintains `depth_s`
+/// (feed = consume rate), so it only advances `at` without changing
+/// `depth_s`.
+struct BurstBudget {
+    /// Seconds of audio in audio-io's ring as of `at`.
+    depth_s: f32,
+    /// Reference instant for `depth_s`.
+    at: Instant,
+    /// Maximum ring depth we'll push to — burst stops here. 5 s matches
+    /// the prebuffer the old single-`/speak` path unconditionally sent.
+    capacity_s: f32,
+}
+
+impl BurstBudget {
+    fn new(capacity_s: f32) -> Self {
+        Self {
+            depth_s: 0.0,
+            at: Instant::now(),
+            capacity_s,
+        }
+    }
+
+    /// Expected ring depth right now, accounting for realtime drain
+    /// since `at`. Saturates at 0 (audio-io can't queue negative audio).
+    fn current_depth_s(&self) -> f32 {
+        let elapsed = self.at.elapsed().as_secs_f32();
+        (self.depth_s - elapsed).max(0.0)
+    }
+
+    /// How many more seconds can be burst-pushed before the ring is at
+    /// capacity. The next call (`/speak` or `/append`) reads this once
+    /// and bursts up to that many seconds, then paces the rest.
+    fn available_burst_s(&self) -> f32 {
+        (self.capacity_s - self.current_depth_s()).max(0.0)
+    }
+
+    /// Record a burst send of `secs` seconds. The send is treated as
+    /// instantaneous on the wire, so the entire `secs` lands in the
+    /// ring immediately and starts draining from `at = now`.
+    fn record_burst(&mut self, secs: f32) {
+        self.depth_s = self.current_depth_s() + secs;
+        self.at = Instant::now();
+    }
+
+    /// Record a paced span of `_secs` seconds at realtime cadence. The
+    /// ring depth is unchanged (feed rate ≈ drain rate during pacing),
+    /// but `at` jumps forward so subsequent `current_depth_s()` calls
+    /// don't double-count the wall-clock spent pacing as additional
+    /// drain time.
+    fn record_paced(&mut self, _secs: f32) {
+        self.at = Instant::now();
+    }
+
+    /// Forced reset (called by `/speak` after a `/spk/stop`). audio-io's
+    /// ring has been dropped, so the budget restarts at empty.
+    fn reset(&mut self) {
+        self.depth_s = 0.0;
+        self.at = Instant::now();
+    }
+}
+
+/// Burst capacity in seconds. Must match the audio length the old code
+/// unconditionally bursted (PREBUFFER_BATCHES × BATCH_MS = 10 × 500 ms
+/// = 5 s). If you tune this, audit `push_to_spk`'s pacing math too.
+const BURST_CAPACITY_S: f32 = 5.0;
 
 #[derive(Deserialize)]
 struct SpeakBody {
@@ -154,11 +255,13 @@ async fn main() -> Result<()> {
             .context("build reqwest client")?,
         current_task: Arc::new(Mutex::new(None)),
         speak_permit: Arc::new(Semaphore::new(1)),
+        burst_budget: Arc::new(Mutex::new(BurstBudget::new(BURST_CAPACITY_S))),
     };
 
     let app = Router::new()
         .route("/health", get(health))
         .route("/speak", post(speak))
+        .route("/append", post(append))
         .route("/finalize", post(finalize))
         .route("/stop", post(stop))
         .with_state(state);
@@ -180,8 +283,34 @@ async fn health() -> Json<Value> {
     Json(json!({"ok": true}))
 }
 
+/// api① — start of turn or barge-in.
+///
+/// Forcibly cancels any in-flight task, POSTs `/spk/stop` to drop
+/// audio-io's playback ring, and resets the burst budget. Then
+/// synthesises the new utterance and pushes from a fresh 5 s budget.
 async fn speak(State(state): State<AppState>, Json(body): Json<SpeakBody>) -> Response {
-    let text = body.text.trim().to_string();
+    enter_speak(state, body.text, ApiMode::Speak).await
+}
+
+/// api② — continuation within the same turn.
+///
+/// Does NOT cancel the in-flight task or reset the budget — instead,
+/// queues behind `speak_permit` and consumes whatever burst headroom
+/// is left after realtime drain. Lets the orchestrator hand off
+/// per-sentence utterances back-to-back without re-prebuffering 5 s
+/// each time (which used to overflow audio-io's ring; see issue #16).
+async fn append(State(state): State<AppState>, Json(body): Json<SpeakBody>) -> Response {
+    enter_speak(state, body.text, ApiMode::Append).await
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ApiMode {
+    Speak,  // api① — reset budget + cancel previous
+    Append, // api② — keep current budget + no cancel
+}
+
+async fn enter_speak(state: AppState, text: String, mode: ApiMode) -> Response {
+    let text = text.trim().to_string();
     if text.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
@@ -197,18 +326,51 @@ async fn speak(State(state): State<AppState>, Json(body): Json<SpeakBody>) -> Re
             .into_response();
     }
 
-    // Cancel any in-flight task before starting the new one. This is
-    // the barge-in case (orchestrator preferring the new utterance
-    // over the old reply); aborting the previous task makes the
-    // previous handler's `await task` raise JoinError::is_cancelled
-    // and return 499 to its caller.
+    if mode == ApiMode::Speak {
+        // Barge-in: tear down the in-flight task and the audio already
+        // queued in audio-io's ring, then reset the burst budget so
+        // the new utterance starts from a full 5 s headroom.
+        let prev_abort = {
+            let mut guard = state.current_task.lock().await;
+            guard.take()
+        };
+        if let Some(prev) = prev_abort {
+            prev.abort();
+            // Drop already-buffered playback. The abort above stops
+            // further frames from being WS-pushed, but audio-io still
+            // has up to playback_buffer_ms of ring on the speaker —
+            // without /spk/stop the user keeps hearing the cancelled
+            // utterance for up to 10 s (fixes PR #15 review #27).
+            if let Some(base) = state.cfg.audio_io_base.as_deref() {
+                match state
+                    .http
+                    .post(format!("{}/spk/stop", base))
+                    .timeout(Duration::from_secs(2))
+                    .send()
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => warn!("POST /spk/stop after barge-in failed: {}", e),
+                }
+            }
+        }
+        state.burst_budget.lock().await.reset();
+    }
+    // Append doesn't cancel or reset — the previous task (if any) will
+    // complete naturally, and speak_permit serialises us behind it.
+
     let task = tokio::spawn(speak_one(state.clone(), text));
     let abort = task.abort_handle();
     {
+        // Store our abort handle so a subsequent /speak can cancel us.
+        // For ApiMode::Speak we already take()d above so this just
+        // installs ours; for ApiMode::Append the slot may hold a stale
+        // handle of a task that's already running (and which we must
+        // NOT abort — that's why Append doesn't call abort here).
+        // Replace either way: the stored handle's purpose is "what the
+        // NEXT /speak should abort", and that's us now.
         let mut guard = state.current_task.lock().await;
-        if let Some(prev) = guard.replace(abort) {
-            prev.abort();
-        }
+        guard.replace(abort);
     }
 
     match task.await {
@@ -298,6 +460,11 @@ async fn stop(State(state): State<AppState>) -> Json<Value> {
             Err(e) => warn!("POST /spk/stop failed: {}", e),
         }
     }
+    // Ring is now empty (or being emptied). Resetting the budget here
+    // means the next /speak or /append starts from a full 5 s headroom
+    // — without it, /append-after-/stop would think the ring still
+    // holds the cancelled audio and refuse to burst.
+    state.burst_budget.lock().await.reset();
     Json(json!({"ok": true, "cancelled": cancelled}))
 }
 
@@ -363,7 +530,13 @@ async fn speak_one(state: AppState, text: String) -> Result<Value> {
         .as_deref()
         .ok_or_else(|| anyhow!("SPK_URL not configured (speak_one invariant violated)"))?;
     let push_t = Instant::now();
-    let sent = push_to_spk(spk_url, &pcm, state.cfg.ws_pacing_ms).await?;
+    let sent = push_to_spk(
+        spk_url,
+        &pcm,
+        state.cfg.ws_pacing_ms,
+        state.burst_budget.clone(),
+    )
+    .await?;
     info!(
         elapsed_ms = push_t.elapsed().as_millis() as u64,
         "push_to_spk returned"
@@ -487,15 +660,15 @@ fn parse_wav_pcm(bytes: &[u8]) -> Result<Vec<u8>> {
     data.ok_or_else(|| anyhow!("WAV has no data chunk"))
 }
 
-/// Stream `pcm` to audio-io's /spk WS at wall-clock cadence, with
-/// pacing and WS send running as concurrent halves of this task.
+/// Stream `pcm` to audio-io's /spk WS, with pacing and WS send running
+/// as concurrent halves of this task.
 ///
 /// Two concerns drive the structure:
 ///
-///   1. **Batching to 100 ms / message** (FRAMES_PER_BATCH = 5).
-///      Amortizes per-send overhead and gives the pacing loop a 100 ms
-///      budget per cycle instead of 20 ms — small TCP/WS hiccups no
-///      longer eat the entire window.
+///   1. **Batching to 500 ms / message** (FRAMES_PER_BATCH = 25 ×
+///      20 ms FRAME_MS). Amortises per-send overhead and gives the
+///      pacing loop a 500 ms budget per cycle instead of 20 ms —
+///      small TCP/WS hiccups no longer eat the entire window.
 ///   2. **Decoupling pacing from network send** via an in-task mpsc.
 ///      A serial `sleep_until → ws.send().await → repeat` loop
 ///      (everything in one future) is *sequential*: any 150 ms
@@ -515,26 +688,30 @@ fn parse_wav_pcm(bytes: &[u8]) -> Result<Vec<u8>> {
 /// the WS write immediately — a detached `tokio::spawn` would leak
 /// queued batches past /spk/stop).
 ///
+/// **Burst budget (issue #16):** the first N batches are queued back-
+/// to-back (the "burst" phase, lands in audio-io's ring all at once);
+/// the rest are paced at realtime. N is determined dynamically by
+/// `burst_budget.available_burst_s()` — `/speak` resets the budget
+/// so the first call within a turn bursts the full 5 s prebuffer,
+/// while `/append` continues with whatever drain has freed up. Without
+/// this, every continuation re-bursted the full 5 s, overflowing
+/// audio-io's 10 s playback ring and producing the audible drop-outs
+/// the issue describes.
+///
 /// Returns when the last batch has been sent — does NOT wait for
 /// audio-io's ring to drain (that's /finalize's job).
-async fn push_to_spk(spk_url: &str, pcm: &[u8], cadence_ms: u64) -> Result<usize> {
-    // 500 ms-per-batch + 5 s prebuffer + audio-io ring of 10 s.
-    //
-    // Sized to absorb steady-state clock skew between the streamer
-    // (WSL2 docker, drifts 5–15 % vs wall-clock under Hyper-V VM
-    // pause/resume mechanics) and audio-io's cpal hardware clock
-    // (Windows-native, exact 48 kHz). Any single utterance shorter
-    // than ~50 s at 10 % skew finishes before prebuffer drains; up to
-    // ~5 s of WSL2 pause is also absorbed without underrun. The cost
-    // is 5 s latency to first audio — fine for offline TTS testing,
-    // unacceptable for live voice-agent use (revisit prebuffer for
-    // production).
+async fn push_to_spk(
+    spk_url: &str,
+    pcm: &[u8],
+    cadence_ms: u64,
+    burst_budget: Arc<Mutex<BurstBudget>>,
+) -> Result<usize> {
     const FRAMES_PER_BATCH: usize = 25;
     const BYTES_PER_BATCH: usize = FRAMES_PER_BATCH * BYTES_PER_FRAME;
-    // BATCH_MS = FRAMES_PER_BATCH × FRAME_MS = 500 ms = audio length
-    // per batch. The realtime cadence equals this value; cadence_ms
-    // (= WS_PACING_MS env, default 500) gates how often we send.
-    const PREBUFFER_BATCHES: usize = 10;
+    /// Audio length per batch in milliseconds, derived from
+    /// FRAMES_PER_BATCH × FRAME_MS = 25 × 20 = 500. Burst budget
+    /// converts seconds ↔ batches using this constant.
+    const BATCH_MS: u64 = (FRAMES_PER_BATCH as u64) * FRAME_MS;
     // 32 batches × 500 ms = 16 s of in-flight queue between pacing
     // and writer. Larger than any expected single-utterance wire
     // backlog so `tx.send().await` is effectively non-blocking even
@@ -564,9 +741,70 @@ async fn push_to_spk(spk_url: &str, pcm: &[u8], cadence_ms: u64) -> Result<usize
         batches.push(tail);
     }
 
+    // Compute how many batches go in the burst phase based on whatever
+    // headroom audio-io's ring has left (issue #16). At /speak time
+    // budget was just reset, so this is full capacity (= 5 s ÷ BATCH_MS
+    // = 10 batches). At /append time, drain since the previous burst
+    // has freed some of that back. We cap at total_batches so a short
+    // utterance bursts entirely with no paced tail.
+    let total_batches = batches.len();
+    let available_s = burst_budget.lock().await.available_burst_s();
+    let burst_batches = ((available_s * 1000.0 / BATCH_MS as f32) as usize).min(total_batches);
+    let paced_batches = total_batches - burst_batches;
+    let burst_secs = burst_batches as f32 * BATCH_MS as f32 / 1000.0;
+    let paced_secs = paced_batches as f32 * BATCH_MS as f32 / 1000.0;
+    info!(
+        total_batches,
+        burst_batches,
+        paced_batches,
+        available_s = (available_s * 100.0).round() / 100.0,
+        "burst plan"
+    );
+
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(CHANNEL_DEPTH);
 
+    let bb_for_pacing = burst_budget.clone();
     let pacing = async move {
+        let mut batches_iter = batches.into_iter();
+
+        // Burst phase: queue the first `burst_batches` back-to-back
+        // without waiting. The writer drains as fast as the WS allows
+        // and these land in audio-io's ring nearly simultaneously
+        // (CHANNEL_DEPTH provides slack so tx.send rarely blocks).
+        for i in 0..burst_batches {
+            let Some(batch) = batches_iter.next() else {
+                break;
+            };
+            let send_t = Instant::now();
+            if tx.send(batch).await.is_err() {
+                warn!(batch_idx = i, "burst tx closed early — writer dead");
+                return;
+            }
+            let blocked = send_t.elapsed();
+            if blocked > Duration::from_millis(5) {
+                warn!(
+                    batch_idx = i,
+                    blocked_ms = blocked.as_millis() as u64,
+                    "burst tx.send blocked — writer behind"
+                );
+            }
+        }
+        // Account for the burst now so a /append queued behind us
+        // observes the updated budget the moment our pacing yields.
+        // Doing this BEFORE pacing (rather than at end of function)
+        // also means /speak's `cancel_prev` reset path doesn't race
+        // with our final `record_paced` after abort.
+        if burst_batches > 0 {
+            bb_for_pacing.lock().await.record_burst(burst_secs);
+            info!(
+                burst_batches,
+                burst_secs = (burst_secs * 100.0).round() / 100.0,
+                "burst phase done"
+            );
+        }
+
+        // Pace phase: queue remaining batches at cadence_ms intervals.
+        //
         // Wall-clock-anchored pacing. tokio::time::sleep_until uses
         // CLOCK_MONOTONIC (= Instant), which on WSL2 docker can lag
         // SystemTime by ~10–15% — Hyper-V VM scheduling / pause-resume
@@ -588,104 +826,71 @@ async fn push_to_spk(spk_url: &str, pcm: &[u8], cadence_ms: u64) -> Result<usize
         // return Err for every queued batch, flushing the rest of the
         // utterance to the WS as fast as the writer can drain it. We
         // bound that burst on a monotonic floor below (see
-        // `min_inter_send_ms`) — even if wall-clock says "send now",
-        // we never fire batches closer than ~half a cadence apart in
+        // `min_inter_send`) — even if wall-clock says "send now", we
+        // never fire batches closer than ~half a cadence apart in
         // monotonic time.
+        //
+        // Pacing model: after the burst phase, audio-io's ring is at
+        // (burst_batches * BATCH_MS) of buffered audio; the consumer
+        // drains at realtime, so by t=cadence_ms the ring is one
+        // cadence shorter and we top it up by one BATCH_MS. The +1 in
+        // `offset_ms = (j + 1) * cadence_ms` keeps the first paced
+        // send anchored one cadence after the burst end (rather than
+        // at t=0), preserving that ring depth instead of letting it
+        // deplete first.
+        //
+        // cadence_ms < BATCH_MS = overrate (each batch delivers
+        // BATCH_MS of audio in cadence_ms wall-clock), which steadily
+        // fills audio-io's ring above the steady state and tolerates a
+        // faster-than-reported cpal hardware clock. Overrate cannot
+        // "recover" the burst's head start in any short time — it only
+        // catches up at (BATCH_MS - cadence_ms) per tick, by design.
         let mut start_wall = std::time::SystemTime::now();
         let start_inst = Instant::now();
-        // Half a cadence is the floor: comfortably above the cadence_ms
-        // overrate range (WS_PACING_MS=400 ms → floor 200 ms ≈ batch
-        // duration / 2.5, still tolerable for the ring) and well above
-        // any legitimate WSL2 monotonic-vs-wall skew, so the cap only
-        // fires on a genuine wall-clock forward jump.
         let min_inter_send = Duration::from_millis(cadence_ms / 2);
         let mut last_send_inst = start_inst;
-        info!("pacing start");
+        info!(paced_batches, "pacing start");
         let mut last_late_ms: u64 = 0;
         let mut max_late_ms: u64 = 0;
         let mut late_ticks: u32 = 0;
         let mut wall_jumps: u32 = 0;
-        for (i, batch) in batches.into_iter().enumerate() {
-            if i >= PREBUFFER_BATCHES {
-                // Pacing model: keep ~5 s of audio in audio-io's ring at
-                // steady state. After the prebuffer burst, audio-io is at
-                // (PREBUFFER_BATCHES * BATCH_MS) of buffered audio; the
-                // consumer has been draining at realtime since the first
-                // batch arrived, so by t=cadence_ms the ring is at
-                // ((PREBUFFER_BATCHES * BATCH_MS) - cadence_ms) and we
-                // top it up by BATCH_MS each tick.
-                //
-                // This is NOT strict just-in-time pacing (= send batch i
-                // at t=i*cadence_ms). That model would let the prebuffer
-                // fully drain before the next send → ring at 0 ms = high
-                // underrun risk. The +1 here is intentional: the first
-                // paced send happens at t=cadence_ms (one cadence after
-                // the burst), keeping the ring topped up rather than
-                // letting it deplete first.
-                //
-                // Cadence is env-overridable so an operator can compensate
-                // for measured environment drift (cf. WS_PACING_MS in
-                // Config). cadence_ms < BATCH_MS = overrate (each batch
-                // delivers BATCH_MS of audio in cadence_ms wall-clock),
-                // which steadily fills audio-io's ring above the steady
-                // state and tolerates a faster-than-reported cpal hardware
-                // clock. NB: overrate cannot "recover" the prebuffer's 5 s
-                // head start in any short time — it only catches up at
-                // (BATCH_MS - cadence_ms) per tick, which is by design.
-                let offset_ms = (i - PREBUFFER_BATCHES + 1) as u64 * cadence_ms;
-                let target = start_wall + Duration::from_millis(offset_ms);
-                loop {
-                    let now_wall = std::time::SystemTime::now();
-                    let remaining_wall = target
-                        .duration_since(now_wall)
-                        .unwrap_or(Duration::ZERO);
-                    // Monotonic floor: protect against an unbounded
-                    // burst if SystemTime stepped forward (NTP / VM
-                    // resume). last_send_inst is set after the prior
-                    // tx.send, so this naturally throttles to
-                    // ≥ min_inter_send between sends.
-                    let monotonic_remaining =
-                        min_inter_send.saturating_sub(last_send_inst.elapsed());
-                    let remaining = remaining_wall.max(monotonic_remaining);
-                    if remaining.is_zero() {
-                        break;
-                    }
-                    // 5 ms cap on Linux is fine — tokio's timer runs at
-                    // ~1 ms granularity. On Windows the default tokio
-                    // timer resolution is ~15.6 ms, so this nap may
-                    // overshoot by ~10 ms per iteration and inflate
-                    // `late_ticks_ge_5ms`. The streamer is only
-                    // expected to run in Linux containers (compose),
-                    // so we don't paper over that here.
-                    let nap = remaining.min(Duration::from_millis(5));
-                    sleep(nap).await;
+        for (j, batch) in batches_iter.enumerate() {
+            let offset_ms = (j + 1) as u64 * cadence_ms;
+            let target = start_wall + Duration::from_millis(offset_ms);
+            loop {
+                let now_wall = std::time::SystemTime::now();
+                let remaining_wall = target
+                    .duration_since(now_wall)
+                    .unwrap_or(Duration::ZERO);
+                // Monotonic floor: protect against an unbounded burst
+                // if SystemTime stepped forward (NTP / VM resume).
+                let monotonic_remaining =
+                    min_inter_send.saturating_sub(last_send_inst.elapsed());
+                let remaining = remaining_wall.max(monotonic_remaining);
+                if remaining.is_zero() {
+                    break;
                 }
-                if let Ok(late) = std::time::SystemTime::now().duration_since(target) {
-                    let late_ms = late.as_millis() as u64;
-                    last_late_ms = late_ms;
-                    if late_ms > max_late_ms {
-                        max_late_ms = late_ms;
-                    }
-                    if late_ms >= 5 {
-                        late_ticks += 1;
-                    }
-                    // If we're > 2 cadences late, treat it as a
-                    // wall-clock forward jump rather than a legitimate
-                    // pacing miss. Re-anchor start_wall to "now minus
-                    // current offset" so subsequent batches don't all
-                    // see target in the past. The monotonic floor above
-                    // already prevents the burst itself; this just
-                    // keeps the late/jitter metrics meaningful.
-                    if late_ms > cadence_ms * 2 {
-                        wall_jumps += 1;
-                        warn!(
-                            late_ms,
-                            batch_idx = i,
-                            "wall-clock jumped forward; re-anchoring pacing"
-                        );
-                        start_wall = std::time::SystemTime::now()
-                            - Duration::from_millis(offset_ms);
-                    }
+                let nap = remaining.min(Duration::from_millis(5));
+                sleep(nap).await;
+            }
+            if let Ok(late) = std::time::SystemTime::now().duration_since(target) {
+                let late_ms = late.as_millis() as u64;
+                last_late_ms = late_ms;
+                if late_ms > max_late_ms {
+                    max_late_ms = late_ms;
+                }
+                if late_ms >= 5 {
+                    late_ticks += 1;
+                }
+                if late_ms > cadence_ms * 2 {
+                    wall_jumps += 1;
+                    warn!(
+                        late_ms,
+                        batch_idx = j,
+                        "wall-clock jumped forward; re-anchoring pacing"
+                    );
+                    start_wall = std::time::SystemTime::now()
+                        - Duration::from_millis(offset_ms);
                 }
             }
             let send_t = Instant::now();
@@ -693,18 +898,21 @@ async fn push_to_spk(spk_url: &str, pcm: &[u8], cadence_ms: u64) -> Result<usize
                 break;
             }
             last_send_inst = Instant::now();
-            // tx.send.await on tokio::sync::mpsc only blocks when the
-            // channel is full; with CHANNEL_DEPTH = 32 and a fast
-            // writer it should be sub-µs. Anything bigger means
-            // back-pressure from the writer = the writer can't keep up.
             let send_elapsed = send_t.elapsed();
             if send_elapsed > Duration::from_millis(5) {
                 warn!(
-                    batch_idx = i,
+                    batch_idx = j,
                     blocked_ms = send_elapsed.as_millis() as u64,
                     "pacing tx.send blocked — channel saturated, writer behind"
                 );
             }
+        }
+        // Account for the paced portion. record_paced just snaps `at`
+        // to now without changing depth_s — paced spans feed at the
+        // same rate audio-io drains, so the ring depth right after
+        // pacing matches the depth right after the burst.
+        if paced_batches > 0 {
+            bb_for_pacing.lock().await.record_paced(paced_secs);
         }
         // Both clocks reported so the operator can confirm the WSL2
         // wall-vs-monotonic skew: a healthy run has both within a few
@@ -824,5 +1032,76 @@ async fn drain_handshake_inner(spk_url: &str) -> Result<()> {
             Message::Binary(_) | Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
             Message::Close(_) => bail!("WS closed before drained"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #16 worked example, time-compressed.
+    ///
+    /// Capacity 5 s, four 2 s utterances back-to-back with ~0 gap.
+    /// Expected burst plan per call:
+    ///   1. api①  budget reset → burst 2 s (≥ all 2 s of audio).
+    ///   2. api②  available 3 s → burst 2 s.
+    ///   3. api②  available 1 s → burst 1 s, pace 1 s.
+    ///   4. api②  available 0 s → burst 0 s, pace 2 s.
+    ///
+    /// We can't sleep through realtime in a unit test, so this
+    /// exercises only the budget arithmetic (`record_burst` /
+    /// `available_burst_s`). The paced-span side effect is the time-
+    /// advancing `record_paced` — covered separately below.
+    #[test]
+    fn issue_16_worked_example_burst_amounts() {
+        let mut b = BurstBudget::new(5.0);
+        b.reset();
+
+        // Call 1 (api①): audio 2 s, all fits in fresh 5 s budget.
+        assert!((b.available_burst_s() - 5.0).abs() < 1e-3);
+        let burst1 = 2.0f32.min(b.available_burst_s());
+        assert!((burst1 - 2.0).abs() < 1e-3);
+        b.record_burst(burst1);
+
+        // Call 2 (api②): immediate. depth = 2 → 3 s headroom.
+        let avail2 = b.available_burst_s();
+        assert!(avail2 > 2.9 && avail2 < 3.05, "avail2={avail2}");
+        let burst2 = 2.0f32.min(avail2);
+        assert!((burst2 - 2.0).abs() < 1e-3);
+        b.record_burst(burst2);
+
+        // Call 3 (api②): immediate. depth = 4 → 1 s headroom, paces 1 s.
+        let avail3 = b.available_burst_s();
+        assert!(avail3 > 0.9 && avail3 < 1.05, "avail3={avail3}");
+        let burst3 = 2.0f32.min(avail3);
+        assert!((burst3 - 1.0).abs() < 0.05);
+        b.record_burst(burst3);
+        b.record_paced(2.0 - burst3);
+
+        // Call 4 (api②): immediate after pacing kept depth at 5 →
+        // 0 headroom, full 2 s is paced.
+        let avail4 = b.available_burst_s();
+        assert!(avail4 < 0.05, "avail4={avail4}");
+    }
+
+    #[test]
+    fn budget_decays_with_realtime_drain() {
+        // Manually fast-forward `at` to simulate elapsed wall-clock.
+        let mut b = BurstBudget::new(5.0);
+        b.record_burst(5.0);
+        assert!(b.available_burst_s() < 0.05);
+        // 3 s later, audio-io has drained 3 s of the burst → 3 s headroom.
+        b.at = Instant::now() - Duration::from_secs(3);
+        let avail = b.available_burst_s();
+        assert!(avail > 2.9 && avail < 3.05, "avail={avail}");
+    }
+
+    #[test]
+    fn reset_zeros_the_depth() {
+        let mut b = BurstBudget::new(5.0);
+        b.record_burst(4.0);
+        assert!(b.available_burst_s() < 1.05);
+        b.reset();
+        assert!((b.available_burst_s() - 5.0).abs() < 1e-3);
     }
 }

--- a/text-to-speech/streamer/src/main.rs
+++ b/text-to-speech/streamer/src/main.rs
@@ -31,6 +31,7 @@
 //! task surfaces as 499 Client Closed Request so the caller can
 //! distinguish "interrupted" from synth/network errors.
 
+use std::collections::VecDeque;
 use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -118,9 +119,19 @@ struct AppState {
     // owned by the awaiting handler. This is what lets the cancelled
     // request return 499 cleanly while the new request awaits its
     // own task.
-    current_task: Arc<Mutex<Option<AbortHandle>>>,
+    //
+    // FIFO of every in-flight + permit-waiting task's abort handle.
+    // `/speak` (barge-in) drains the whole queue and aborts each —
+    // not just the running task, but also any `/append`s queued
+    // behind speak_permit, so a barge-in really cuts everything that
+    // was scheduled for the previous turn. `/append` only pushes its
+    // own handle (it must NOT abort the previous task — that's the
+    // whole point of api②). Completed handles are reaped lazily on
+    // each push via `retain(!is_finished())` so the queue doesn't
+    // grow without bound during long sessions.
+    barge_in_targets: Arc<Mutex<VecDeque<AbortHandle>>>,
     // Single-permit semaphore around speak_one. A burst of /speak
-    // requests aborts the previous task via current_task.abort(), but
+    // requests aborts the previous tasks via barge_in_targets, but
     // the abort signal only takes effect at the next .await point —
     // a request mid-`reqwest::send().await` keeps running until the
     // network resolves. The semaphore makes the new request wait for
@@ -253,7 +264,7 @@ async fn main() -> Result<()> {
             .timeout(Duration::from_secs(60))
             .build()
             .context("build reqwest client")?,
-        current_task: Arc::new(Mutex::new(None)),
+        barge_in_targets: Arc::new(Mutex::new(VecDeque::new())),
         speak_permit: Arc::new(Semaphore::new(1)),
         burst_budget: Arc::new(Mutex::new(BurstBudget::new(BURST_CAPACITY_S))),
     };
@@ -327,50 +338,54 @@ async fn enter_speak(state: AppState, text: String, mode: ApiMode) -> Response {
     }
 
     if mode == ApiMode::Speak {
-        // Barge-in: tear down the in-flight task and the audio already
-        // queued in audio-io's ring, then reset the burst budget so
-        // the new utterance starts from a full 5 s headroom.
+        // Barge-in: tear down EVERY task scheduled for the previous
+        // turn — the one currently holding speak_permit AND any
+        // /appends queued behind it — plus the audio already buffered
+        // in audio-io's ring. Then reset the burst budget so the new
+        // utterance starts from a full 5 s headroom.
         //
-        // current_task may hold the AbortHandle of a task that has
-        // already completed normally (we don't proactively clear it
-        // when speak_one returns). Calling /spk/stop on that branch
-        // sets audio-io's flush flag, and the *new* utterance's
-        // first Frame then gets eaten by the cancellation path in
-        // playback_producer_task — manifesting as the head of the
-        // 2nd-turn 1st sentence being clipped to ~500 ms of silence
-        // (the "うん" → "ん" head-clip seen in production). Guard
-        // with is_finished() so /spk/stop only fires on a real
-        // barge-in (previous task still running).
-        let prev_abort = {
-            let mut guard = state.current_task.lock().await;
-            guard.take()
+        // Why drain the whole queue instead of just the head: if A is
+        // running and B/C are permit-waiting behind it, aborting only
+        // the latest (the old single-slot design) would leave A, B, C
+        // alive — A keeps pushing to /spk after our /spk/stop, and B/C
+        // run their full synth→push cycle after E acquires the permit.
+        // Both are barge-in regressions.
+        //
+        // is_finished() guards against firing /spk/stop on a "stale"
+        // queue — if every entry already completed normally, the new
+        // utterance's first Frame would otherwise be eaten by the
+        // cancellation path in playback_producer_task and the head of
+        // the 2nd-turn 1st sentence ends up clipped to ~500 ms of
+        // silence (the "うん" → "ん" head-clip seen in production).
+        let prev: Vec<AbortHandle> = {
+            let mut guard = state.barge_in_targets.lock().await;
+            guard.drain(..).collect()
         };
-        if let Some(prev) = prev_abort {
-            if !prev.is_finished() {
-                prev.abort();
-                // Drop already-buffered playback. The abort above stops
-                // further frames from being WS-pushed, but audio-io
-                // still has up to playback_buffer_ms of ring on the
-                // speaker — without /spk/stop the user keeps hearing
-                // the cancelled utterance for up to 10 s (fixes
-                // PR #15 review #27).
-                if let Some(base) = state.cfg.audio_io_base.as_deref() {
-                    match state
-                        .http
-                        .post(format!("{}/spk/stop", base))
-                        .timeout(Duration::from_secs(2))
-                        .send()
-                        .await
-                    {
-                        Ok(_) => {}
-                        Err(e) => warn!("POST /spk/stop after barge-in failed: {}", e),
-                    }
+        let mut had_active = false;
+        for handle in prev {
+            if !handle.is_finished() {
+                handle.abort();
+                had_active = true;
+            }
+        }
+        if had_active {
+            // Drop already-buffered playback. The aborts above stop
+            // further frames from being WS-pushed, but audio-io still
+            // has up to playback_buffer_ms of ring on the speaker —
+            // without /spk/stop the user keeps hearing the cancelled
+            // utterance for up to 10 s (fixes PR #15 review #27).
+            if let Some(base) = state.cfg.audio_io_base.as_deref() {
+                match state
+                    .http
+                    .post(format!("{}/spk/stop", base))
+                    .timeout(Duration::from_secs(2))
+                    .send()
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => warn!("POST /spk/stop after barge-in failed: {}", e),
                 }
             }
-            // Else: previous task already finished, the stored
-            // AbortHandle is just a stale reference — drop it without
-            // touching audio-io. The new task's Frames will land in a
-            // clean ring with no flush flag racing them.
         }
         state.burst_budget.lock().await.reset();
     }
@@ -380,15 +395,14 @@ async fn enter_speak(state: AppState, text: String, mode: ApiMode) -> Response {
     let task = tokio::spawn(speak_one(state.clone(), text));
     let abort = task.abort_handle();
     {
-        // Store our abort handle so a subsequent /speak can cancel us.
-        // For ApiMode::Speak we already take()d above so this just
-        // installs ours; for ApiMode::Append the slot may hold a stale
-        // handle of a task that's already running (and which we must
-        // NOT abort — that's why Append doesn't call abort here).
-        // Replace either way: the stored handle's purpose is "what the
-        // NEXT /speak should abort", and that's us now.
-        let mut guard = state.current_task.lock().await;
-        guard.replace(abort);
+        // Append our handle so a future /speak can cancel us. Reap
+        // completed handles first so the queue doesn't grow with every
+        // /append in a long session (abort on a finished handle is a
+        // no-op, but we'd still walk over the dead entries on every
+        // barge-in).
+        let mut guard = state.barge_in_targets.lock().await;
+        guard.retain(|h| !h.is_finished());
+        guard.push_back(abort);
     }
 
     match task.await {
@@ -455,13 +469,18 @@ async fn finalize(State(state): State<AppState>) -> Response {
 
 async fn stop(State(state): State<AppState>) -> Json<Value> {
     let cancelled = {
-        let mut guard = state.current_task.lock().await;
-        if let Some(prev) = guard.take() {
-            prev.abort();
-            true
-        } else {
-            false
+        let prev: Vec<AbortHandle> = {
+            let mut guard = state.barge_in_targets.lock().await;
+            guard.drain(..).collect()
+        };
+        let mut any_live = false;
+        for handle in prev {
+            if !handle.is_finished() {
+                handle.abort();
+                any_live = true;
+            }
         }
+        any_live
     };
     // Drop already-buffered playback. The abort above stops further
     // frames from being WS-pushed, but audio-io still has a few

--- a/text-to-speech/streamer/src/main.rs
+++ b/text-to-speech/streamer/src/main.rs
@@ -1007,7 +1007,13 @@ async fn drain_handshake_inner(spk_url: &str) -> Result<()> {
         .await
         .context("WS send eos")?;
     loop {
-        let msg = timeout(Duration::from_secs(2), ws.next())
+        // Per-recv timeout. audio-io's Eos handler sleeps until the
+        // cpal ring is fully drained, which takes (real audio
+        // duration) seconds — a turn's last sentence(s) can easily
+        // queue ~5 s before /finalize fires. The earlier 2 s cap was
+        // tripping legitimate multi-sentence drains and surfacing as
+        // "drain recv timeout" in production.
+        let msg = timeout(Duration::from_secs(10), ws.next())
             .await
             .context("drain recv timeout")?
             .ok_or_else(|| anyhow!("WS closed before drained"))?

--- a/text-to-speech/streamer/src/main.rs
+++ b/text-to-speech/streamer/src/main.rs
@@ -204,12 +204,13 @@ impl BurstBudget {
         self.at = Instant::now();
     }
 
-    /// Record a paced span of `_secs` seconds at realtime cadence. The
-    /// ring depth is unchanged (feed rate ≈ drain rate during pacing),
-    /// but `at` jumps forward so subsequent `current_depth_s()` calls
-    /// don't double-count the wall-clock spent pacing as additional
-    /// drain time.
-    fn record_paced(&mut self, _secs: f32) {
+    /// Record that a paced span just finished. The ring depth is
+    /// unchanged (feed rate ≈ drain rate during pacing), but `at` snaps
+    /// to now so subsequent `current_depth_s()` calls don't double-count
+    /// the wall-clock spent pacing as additional drain time. The actual
+    /// pacing duration is irrelevant to the budget arithmetic (only the
+    /// "now" anchor matters), so no `secs` argument.
+    fn record_paced(&mut self) {
         self.at = Instant::now();
     }
 
@@ -781,12 +782,11 @@ async fn push_to_spk(
     let burst_batches = ((available_s * 1000.0 / BATCH_MS as f32) as usize).min(total_batches);
     let paced_batches = total_batches - burst_batches;
     let burst_secs = burst_batches as f32 * BATCH_MS as f32 / 1000.0;
-    let paced_secs = paced_batches as f32 * BATCH_MS as f32 / 1000.0;
     info!(
         total_batches,
         burst_batches,
         paced_batches,
-        available_s = (available_s * 100.0).round() / 100.0,
+        available_s = format!("{:.2}", available_s),
         "burst plan"
     );
 
@@ -827,7 +827,7 @@ async fn push_to_spk(
             bb_for_pacing.lock().await.record_burst(burst_secs);
             info!(
                 burst_batches,
-                burst_secs = (burst_secs * 100.0).round() / 100.0,
+                burst_secs = format!("{:.2}", burst_secs),
                 "burst phase done"
             );
         }
@@ -941,7 +941,7 @@ async fn push_to_spk(
         // same rate audio-io drains, so the ring depth right after
         // pacing matches the depth right after the burst.
         if paced_batches > 0 {
-            bb_for_pacing.lock().await.record_paced(paced_secs);
+            bb_for_pacing.lock().await.record_paced();
         }
         // Both clocks reported so the operator can confirm the WSL2
         // wall-vs-monotonic skew: a healthy run has both within a few
@@ -1111,7 +1111,7 @@ mod tests {
         let burst3 = 2.0f32.min(avail3);
         assert!((burst3 - 1.0).abs() < 0.05);
         b.record_burst(burst3);
-        b.record_paced(2.0 - burst3);
+        b.record_paced();
 
         // Call 4 (api②): immediate after pacing kept depth at 5 →
         // 0 headroom, full 2 s is paced.


### PR DESCRIPTION
## Summary

- **TTS**: `/speak` (api①) と `/append` (api②) を分離し、burst budget を共有 (#75878b1)。orchestrator 側でどちらの API を使ったか可視化 (#54fafe8)。barge-in 時は permit 待ちの /append を含む **全タスク** を abort できるよう `current_task` を FIFO `barge_in_targets` に置き換え (#981cda8)。
- **LLM**: Gemma 4 MTP build path を導入 (#831f9cc)。consumer GPU VRAM に収めるため import 時に量子化、最終的に safetensors target に revert。context を 8k に絞り、CUDA MMQ kernel を強制 (#7bd983c)。MTP 判定パターンを 4タグ完全一致に絞り `*-mtp-bf16` 等は plain pull にフォールスルー。
- **Streamer 安定化**: `/start` POST は `/speak` 時のみに限定し `/append` ではスキップ (#8ce334c, #e5a4a68)。drain handshake のタイムアウトを 10s に (#c456e5c)。barge-in (`/spk/stop`) は前タスク実行中のみ (#a7e139e)。
- **audio-io**: 2nd-turn TTS 冒頭が切れる問題に対し silence keep-alive を追加 (#1ff02b9)。`select!` リファクタのインデントを整え、Eos ドレインと keep-alive の相互作用を doc コメントで明文化。
- **Compose**: `kklocalagent_default` のサブネットを `172.25.0.0/16` に固定 (#efd68d1)。

## Test plan

- [ ] `/speak` → `/append` のシーケンスで burst budget が共有されているか確認
- [ ] 2nd-turn 以降の TTS の頭切れが解消されているか確認（手動 E2E: `/speak → /finalize → /speak` を 2 ターン以上回し、2 ターン目以降の 1 文目冒頭が欠けないこと）
- [ ] Eos ドレイン拡張 (2s → 10s) で誤発火しないこと（長い最終文の `/finalize` が `drain recv timeout` を出さず正常完了することを確認）
- [ ] Gemma 4 MTP が GPU VRAM に収まりロード成功するか確認
- [ ] `LLM_MODEL=gemma4:31b-coding-mtp-bf16` のようなライブラリタグが plain pull に流れることを確認（MTP 分岐に吸い込まれない）
- [ ] barge-in が走行中タスク **および permit 待ちの後続タスク** をまとめて abort することを確認（A 実行中に B を `/append` で投入し、続けて `/speak` C を投入したとき B の音声が再生されないこと）

Close #16 

🤖 Generated with [Claude Code](https://claude.com/claude-code)