### PR TITLE
feat(agent): tool-calling 基盤 + 音声再生/停止 tool、audio-io 並列 track 対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -395,12 +395,22 @@ VAD_DENOISE=true
 VAD_MIN_UTTERANCE_RMS_DBFS=-50
 
 # -----------------------------------------------------------------------
-# AGENT_SYSTEM_PROMPT — voice-assistant persona, prepended to every
-# turn at LLM-invoke time on the `agent` service (LangGraph). Empty
-# string disables the system message entirely. Default in
-# compose.yaml is the Japanese-first voice-friendly persona; override
-# here to change tone, switch primary language, or specialise (e.g.
-# "you are a kitchen timer assistant").
+# AGENT_SYSTEM_PROMPT — voice-assistant *persona* (who the agent is
+# and how it talks), prepended to every turn at LLM-invoke time on
+# the `agent` service (LangGraph). Empty string disables the system
+# message entirely. Default in compose.yaml is the Japanese-first
+# voice-friendly persona; override here to change tone, switch
+# primary language, or specialise (e.g. "you are a kitchen timer
+# assistant").
+#
+# Scope split — keep this prompt about *speaking style only*:
+#   AGENT_SYSTEM_PROMPT       — persona / tone / language / brevity
+#                                (read aloud, タメ口, 1-2 sentences, ...)
+#   AGENT_TOOL_SYSTEM_SUFFIX  — tool-use policy / retry behaviour /
+#                                multi-step planning (see below)
+# When AGENT_TOOLS_ENABLED=true, the suffix is appended after this
+# persona on every turn. Mixing tool-use rules in here works but
+# couples the two — prefer keeping the boundary clean.
 #
 # The default tells the model:
 #   - replies are spoken aloud (no markdown / lists / code blocks)
@@ -450,3 +460,50 @@ AGENT_SYSTEM_PROMPT="You are a voice assistant; your replies are spoken aloud, s
 # `:ro` is hard-coded in compose.yaml — edit the mount line directly
 # if you need rw.
 #AGENT_SHARE_DIR=/home/me/voice-share
+
+# -----------------------------------------------------------------------
+# AGENT_TOOL_RECURSION_LIMIT — max LangGraph step count per turn in
+# the ReAct loop (agent_node → tools → agent_node → ...). Roughly
+# `floor(N / 2)` tool calls in a chain — default 6 ≈ 3 tool calls.
+#
+# Bump this if the agent legitimately needs more steps to finish a
+# task (e.g. `ls share/` → `ls share/nikkei/` → `ls share/nikkei/<date>/`
+# → `play_audio_file ...`, which is 4 calls = needs at least 8).
+# Going past the limit makes the agent emit AGENT_TOOL_FALLBACK_TEXT
+# ("うまくできませんでした、すみません。") instead of a real reply.
+#
+# Ignored when AGENT_TOOLS_ENABLED=false.
+#
+# Default: 6
+AGENT_TOOL_RECURSION_LIMIT=20
+
+# -----------------------------------------------------------------------
+# AGENT_TOOL_SYSTEM_SUFFIX — tool-use *behaviour policy*, appended
+# after AGENT_SYSTEM_PROMPT when AGENT_TOOLS_ENABLED=true. Scope
+# split: persona goes in AGENT_SYSTEM_PROMPT (how to talk); this var
+# goes in tool decisions (when to call, how to retry, how to plan).
+#
+# Empty (the default) means the built-in policy in agent/app.py is
+# used. The built-in covers:
+#   - never refer to tool output deictically ("this", "as written") —
+#     restate content in your own words for TTS
+#   - the persona's 1-2 sentence limit applies to the *final* spoken
+#     reply only; during a turn, call as many tools as needed silently
+#   - don't announce intent ("I'll check X") and then end the turn —
+#     the next thing must be the tool call
+#   - before asking the user a clarifying question, check whether a
+#     tool can answer it (date, ls, read_file)
+#   - establish absolute paths and confirm existence before acting on
+#     a file (avoids the "relative path → playback failed" loop)
+#   - on [error] / [denied], hypothesise the cause and retry once
+#     before giving up
+#   - briefly plan multi-step tasks (find → check → act) before
+#     calling the first tool
+#
+# Override here only if you need different etiquette (e.g. a more
+# conservative agent that asks the user before any side-effecting
+# tool). Single-line only in .env; for multi-paragraph instructions
+# edit compose.yaml directly.
+#
+# Default: empty (= use built-in policy)
+#AGENT_TOOL_SYSTEM_SUFFIX=" You have tools — use them, but ask before any side-effecting action."

--- a/.env.example
+++ b/.env.example
@@ -123,7 +123,7 @@
 # Defaults: ggml-medium-q8_0.bin (GPU compose), ggml-small-q8_0.bin
 #           (CPU override — keeps the asr-models download light when
 #            no GPU is available)
-#ASR_MODEL=ggml-large-v3-turbo-q8_0.bin
+ASR_MODEL=ggml-large-v3-turbo-q8_0.bin
 
 # -----------------------------------------------------------------------
 # VOICEVOX_SPEED_SCALE — multiplier on the assistant's speech speed.
@@ -370,7 +370,7 @@
 # steady noise or Whisper hallucinations are a recurring problem.
 #
 # Default: false
-#VAD_DENOISE=true
+VAD_DENOISE=true
 
 # -----------------------------------------------------------------------
 # VAD_MIN_UTTERANCE_RMS_DBFS — SpeechEnded events whose buffered
@@ -392,7 +392,7 @@
 # Set to 0 (or any value >= 0) to disable the gate entirely.
 #
 # Default: -45
-#VAD_MIN_UTTERANCE_RMS_DBFS=-50
+VAD_MIN_UTTERANCE_RMS_DBFS=-50
 
 # -----------------------------------------------------------------------
 # AGENT_SYSTEM_PROMPT — voice-assistant persona, prepended to every
@@ -419,7 +419,7 @@
 # Single-line only — `.env` files don't support multiline values; if
 # you need multi-paragraph instructions, set this in the compose
 # environment block directly (which supports YAML literal blocks).
-#AGENT_SYSTEM_PROMPT=You are a voice assistant; your replies are spoken aloud, so write the way people speak — no markdown, no lists, no code blocks. Keep every response to one or two short sentences. Default to Japanese (日本語) unless the user clearly speaks another language. Maintain a brisk, natural conversational rhythm. Keep wording as simple and minimal as possible — fewer words is better. Skip honorifics (敬語); use casual / plain-form Japanese (タメ口).
+AGENT_SYSTEM_PROMPT="You are a voice assistant; your replies are spoken aloud, so write the way people speak — no markdown, no lists, no code blocks. Keep every response to one or two short sentences. Default to Japanese (日本語) unless the user clearly speaks another language. Maintain a brisk, natural conversational rhythm. Keep wording as simple and minimal as possible — fewer words is better. Skip honorifics (敬語); use casual / plain-form Japanese (タメ口). Input text is produced by ASR (speech-to-text); read it with that in mind — expect transcription noise, dropped particles, and homophone mistakes. If the input doesn't seem to make sense, assume the user's speech may have been only partially or incorrectly transcribed, and respond accordingly (briefly confirm or pick the most plausible meaning)."
 
 # -----------------------------------------------------------------------
 # AGENT_SESSION_IDLE_SEC — seconds of /api/chat silence after which

--- a/.env.example
+++ b/.env.example
@@ -435,3 +435,18 @@ AGENT_SYSTEM_PROMPT="You are a voice assistant; your replies are spoken aloud, s
 #
 # Default: 600 (10 min)
 #AGENT_SESSION_IDLE_SEC=1800
+
+# -----------------------------------------------------------------------
+# AGENT_SHARE_DIR — host directory bind-mounted into the agent
+# container at `/workspace/share` (read-only). Files dropped here on
+# the host become visible to the agent's `read_file` / `run_shell`
+# tools (FILE_ROOT defaults to `/workspace`, so `ls share/` works
+# from the LLM's side).
+#
+# Default in compose.yaml is `./share` (relative to compose.yaml),
+# which Docker auto-creates on first `up` if missing. Override here
+# to point at an existing dir elsewhere on the host.
+#
+# `:ro` is hard-coded in compose.yaml — edit the mount line directly
+# if you need rw.
+#AGENT_SHARE_DIR=/home/me/voice-share

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # kklocalagent
 
+## Server ( the other ) - Client ( audio-io ) 
+
+```bash
+sudo ufw allow from 172.25.0.0/16 to any port 7010 proto tcp comment 'audio-io tunnel for kklocalagent containers'
+sudo ufw reload
+```
+
+```bash
+ssh home -R 0.0.0.0:7010:$(ip route show | awk '/default/ {print $3}'):7010
+```
 
 ```bash
 sudo docker compose -f compose.yaml -f compose.cpu.yaml up -d --build
+
+sudo WW_MODELS=tanuki.onnx WINDOWS_HOST=$(sudo docker network inspect kklocalagent_default --format '{{range .IPAM.Config}}{{.Gateway}}{{end}}') docker compose -f compose.yaml up --build
 ```

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ sudo docker compose -f compose.yaml up -d --build llm agent
 sudo docker compose exec agent python /app/experiments/chat_repl.py
 sudo docker compose down
 ```
+
+## Tools
+
+```bash
+sudo docker compose exec agent python /app/tools.py play_audio_file /workspace/share/foo.wav
+```

--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ sudo docker compose -f compose.yaml -f compose.cpu.yaml up -d --build
 
 sudo WW_MODELS=tanuki.onnx WINDOWS_HOST=$(sudo docker network inspect kklocalagent_default --format '{{range .IPAM.Config}}{{.Gateway}}{{end}}') docker compose -f compose.yaml up --build
 ```
+
+## LLM Chat-mode
+
+```bash
+sudo docker compose -f compose.yaml up -d --build llm agent
+sudo docker compose exec agent python /app/experiments/chat_repl.py
+sudo docker compose down
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ssh home -R 0.0.0.0:7010:$(ip route show | awk '/default/ {print $3}'):7010
 
 ```bash
 sudo docker compose -f compose.yaml -f compose.cpu.yaml up -d --build
-
+sudo WW_MODELS=tanuki.onnx WINDOWS_HOST=$(ip route show | awk '/default/ {print $3}') docker compose -f compose.yaml up --build
 sudo WW_MODELS=tanuki.onnx WINDOWS_HOST=$(sudo docker network inspect kklocalagent_default --format '{{range .IPAM.Config}}{{.Gateway}}{{end}}') docker compose -f compose.yaml up --build
 ```
 

--- a/agent/.dockerignore
+++ b/agent/.dockerignore
@@ -1,0 +1,7 @@
+# Build cache がイメージに混入するのを防ぐ。`COPY experiments /app/experiments`
+# で __pycache__ ごと持ち込んでいたので明示的に除外する。`**/` プレフィックスは
+# サブディレクトリ配下にも適用するため (パターンなしだと build context root の
+# 直下しかマッチしない)。
+**/__pycache__/
+**/*.pyc
+**/*.pyo

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-COPY app.py tools.py /app/
+COPY app.py tools.py sandbox.py /app/
 
 # /data is mounted as a named volume in compose so conversation memory
 # survives `docker compose down && up`. AGENT_DB_PATH defaults to a

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-COPY app.py /app/app.py
+COPY app.py tools.py /app/
 
 # /data is mounted as a named volume in compose so conversation memory
 # survives `docker compose down && up`. AGENT_DB_PATH defaults to a

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -20,6 +20,11 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY app.py tools.py sandbox.py /app/
+# Test ハーネスも image に含める。issue #19 step 2 で追加した chat_repl.py を
+# `docker compose exec agent python /app/experiments/chat_repl.py` で叩ける
+# ようにするため。production 実行では import されないので runtime コストは
+# 無し (数 KB の追加レイヤだけ)。
+COPY experiments /app/experiments
 
 # /data is mounted as a named volume in compose so conversation memory
 # survives `docker compose down && up`. AGENT_DB_PATH defaults to a

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -5,9 +5,13 @@
 # live here.
 FROM python:3.11-slim-bookworm
 
-# curl for the HEALTHCHECK probe.
+# curl for the HEALTHCHECK probe. procps (uptime / free / ps) and
+# iproute2 (ip) are required by the run_shell tool's default allowlist
+# (`uptime`, `ip`); without them the LLM's "ネットワーク状況を教えて"
+# turns into a "command not found" loop. coreutils-only commands
+# (date, df, uname, who) are already in python:slim.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl procps iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/agent/README.md
+++ b/agent/README.md
@@ -82,3 +82,51 @@ operationally:
 * idle-rotated session id
 
 Tools / MCP / approval are explicit follow-ups in issue #10.
+
+## Testing the chat IF directly (issue #19 step 2)
+
+The voice pipeline (orchestrator → tts-streamer → audio-io) is the
+production path, but for verifying tool wiring / system prompt
+tweaks / conversation memory behaviour it's faster to talk to the
+agent over its HTTP IF directly. `experiments/chat_repl.py` is a
+stdlib-only CLI REPL that POSTs to `/api/chat` and streams ndjson
+deltas back as plain text.
+
+The script is baked into the image, so once the stack is up:
+
+```
+docker compose up -d agent llm         # llm is the ollama backend
+docker compose exec agent python /app/experiments/chat_repl.py
+```
+
+Output:
+
+```
+agent: http://localhost:7080
+session=abc12345  tools_enabled=True  idle=3.4s
+Ctrl-D or Ctrl-C to exit.
+
+user> 今何時？
+agent> 今は午後1時44分だよ。
+user>
+```
+
+Continuous turns share the same session (= LangGraph thread_id), so
+"さっき何を聞いた？" picks up the previous turn's content from the
+SqliteSaver checkpoint. Idle past `AGENT_SESSION_IDLE_SEC` rotates
+the session and forgets prior turns.
+
+Tool-related env vars (`AGENT_TOOLS_ENABLED`,
+`AGENT_SHELL_ALLOWLIST`, `AGENT_FILE_ROOT`, `AGENT_TOOL_ACK_*`,
+`AGENT_TOOL_RECURSION_LIMIT`) all take effect at agent restart —
+e.g. `docker compose up -d --force-recreate agent` after editing
+`compose.yaml`. The wire (ndjson) format is identical to what the
+orchestrator sees, so anything that works here will work over voice
+too (modulo TTS-side effects on long sentences, which the
+orchestrator handles separately).
+
+`experiments/tool_calling_probe.py` is a related sanity check —
+POSTs three short canned prompts to ollama directly (no agent
+involvement) to verify Gemma 4 + ollama tool-calling still works
+after a model upgrade. Run from the host with the ollama port
+exposed.

--- a/agent/app.py
+++ b/agent/app.py
@@ -257,6 +257,14 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
     # would feel repetitive on the speaker).
     last_acked_tool: str | None = None
 
+    # Whether any *real* LLM-produced text was yielded (acks don't count).
+    # If a turn ends with this still False — e.g. the LLM called a tool,
+    # got back a `[denied]` ToolMessage, and silently stopped without
+    # generating an apology — we emit `RECURSION_FALLBACK_TEXT` at the
+    # end so the operator never hears total silence. Observed with
+    # gemma4:e4b when allowlist-rejected shell commands feed back.
+    real_content_yielded = False
+
     try:
         async for chunk, _meta in graph.astream(
             input_state, config=config, stream_mode="messages"
@@ -286,6 +294,7 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
             # `list[ContentBlock]` for multimodal — we ignore those
             # because the orchestrator's parser expects str.
             if isinstance(chunk.content, str) and chunk.content:
+                real_content_yielded = True
                 yield {"message": {"content": chunk.content}, "done": False}
     except GraphRecursionError:
         # ReAct loop ran past `recursion_limit` without producing a
@@ -295,6 +304,18 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
         log.warning(
             "recursion limit %d reached for session %s; emitting fallback",
             RECURSION_LIMIT, session_id,
+        )
+        yield {"message": {"content": RECURSION_FALLBACK_TEXT}, "done": False}
+        real_content_yielded = True
+
+    if not real_content_yielded:
+        # Stream ended normally but the LLM produced no text — typically
+        # after a tool error returned `[denied]` / `[error]` content that
+        # the LLM decided not to comment on. Voice agent must always say
+        # SOMETHING; emit the fallback so the speaker isn't dead.
+        log.warning(
+            "no LLM text yielded for session %s; emitting fallback",
+            session_id,
         )
         yield {"message": {"content": RECURSION_FALLBACK_TEXT}, "done": False}
 

--- a/agent/app.py
+++ b/agent/app.py
@@ -54,7 +54,12 @@ from typing import AsyncIterator
 
 import aiosqlite
 from aiohttp import web
-from langchain_core.messages import AIMessageChunk, HumanMessage, SystemMessage
+from langchain_core.messages import (
+    AIMessageChunk,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_ollama import ChatOllama
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.errors import GraphRecursionError
@@ -312,13 +317,28 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
     # end so the operator never hears total silence. Observed with
     # gemma4:e4b when allowlist-rejected shell commands feed back.
     real_content_yielded = False
+    # Did the *most recent* tool call succeed? `_safe_invoke` prefixes
+    # failures with `[error]` / `[denied]`, so anything else means the
+    # action went through. For action-only commands ("play this wav",
+    # "run this shell") gemma3:4b often produces zero follow-up text
+    # after a successful tool — that's expected, not a failure, so we
+    # must NOT speak the apology fallback in that case (the user already
+    # heard the ack and the action happened). Only emit fallback when
+    # the silence really does follow a failure.
+    last_tool_succeeded: bool | None = None
 
     try:
         async for chunk, _meta in graph.astream(
             input_state, config=config, stream_mode="messages"
         ):
+            if isinstance(chunk, ToolMessage):
+                content = chunk.content if isinstance(chunk.content, str) else ""
+                last_tool_succeeded = not content.startswith(
+                    ("[error]", "[denied]")
+                )
+                continue
             if not isinstance(chunk, AIMessageChunk):
-                # ToolMessage / SystemMessage etc — not for TTS.
+                # SystemMessage etc — not for TTS.
                 continue
 
             # Tool-call delta: each partial chunk lists 1+ tool_call_chunks
@@ -356,11 +376,14 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
         yield {"message": {"content": RECURSION_FALLBACK_TEXT}, "done": False}
         real_content_yielded = True
 
-    if not real_content_yielded:
+    if not real_content_yielded and last_tool_succeeded is not True:
         # Stream ended normally but the LLM produced no text — typically
         # after a tool error returned `[denied]` / `[error]` content that
         # the LLM decided not to comment on. Voice agent must always say
-        # SOMETHING; emit the fallback so the speaker isn't dead.
+        # SOMETHING; emit the fallback so the speaker isn't dead. We skip
+        # this when the last tool *succeeded* — for action-only commands
+        # the user already heard the ack and the action happened, so
+        # apologising would contradict reality.
         log.warning(
             "no LLM text yielded for session %s; emitting fallback",
             session_id,

--- a/agent/app.py
+++ b/agent/app.py
@@ -7,9 +7,9 @@ the same body it always sent to ollama:
      "stream": true}
 
 — but the URL now points here. We pull the latest user turn out of
-that body, run a single-node LangGraph chat against an internally
-configured `ChatOllama`, and stream the assistant's deltas back as
-ndjson lines whose shape matches ollama's /api/chat output exactly:
+that body, run a LangGraph chat against an internally configured
+`ChatOllama`, and stream the assistant's deltas back as ndjson lines
+whose shape matches ollama's /api/chat output exactly:
 
     {"message":{"content":"<delta>"},"done":false}\\n
     ...
@@ -32,11 +32,13 @@ Architecture decisions:
   process, so we generate a single session at startup and rotate it
   after `AGENT_SESSION_IDLE_SEC` of no /api/chat traffic (assume the
   operator walked away; the next turn is a fresh conversation).
-* **No tools / MCP / approval in v1** — the graph is one chat node so
-  the orchestrator's existing barge-in path (HTTP cancellation drops
-  the response stream → ChatOllama drops its httpx connection →
-  ollama stops generating) still works without agent-side
-  bookkeeping. Tools land in a follow-up.
+* **Tools (issue #19)** are gated behind `AGENT_TOOLS_ENABLED`. When
+  on, the chat graph is replaced with `create_react_agent` (LLM ↔
+  tool loop). When off, the legacy single-node graph is used so
+  pre-tools behaviour is preserved bit-for-bit. The stream filter
+  drops tool-call deltas (would TTS structured data otherwise) and
+  injects a per-tool "filler ack" chunk (e.g. "ちょっと検索してみるね")
+  before slow tools so the user doesn't sit through a silent gap.
 """
 
 from __future__ import annotations
@@ -55,7 +57,11 @@ from aiohttp import web
 from langchain_core.messages import AIMessageChunk, HumanMessage, SystemMessage
 from langchain_ollama import ChatOllama
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from langgraph.errors import GraphRecursionError
 from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.prebuilt import create_react_agent
+
+from tools import TOOL_ACK_PHRASES, all_tools
 
 log = logging.getLogger("agent")
 
@@ -65,6 +71,30 @@ SYSTEM_PROMPT = os.environ.get("AGENT_SYSTEM_PROMPT", "")
 DB_PATH = os.environ.get("AGENT_DB_PATH", "/data/agent.sqlite")
 SESSION_IDLE_SEC = float(os.environ.get("AGENT_SESSION_IDLE_SEC", "600"))
 PORT = int(os.environ.get("AGENT_PORT", "7080"))
+
+# Feature flag for issue #19. Default off so this PR is a no-op for
+# anyone who doesn't opt in.
+TOOLS_ENABLED = os.environ.get("AGENT_TOOLS_ENABLED", "false").lower() in ("1", "true", "yes")
+# Caps the number of graph steps per turn (agent_node → tools → agent_node
+# → ... ). 6 ≈ 3 tool calls in a chain. Beyond this we surface a fallback
+# voice line rather than loop forever. issue #19 オープン項目 #6 の retry
+# リミット。
+RECURSION_LIMIT = int(os.environ.get("AGENT_TOOL_RECURSION_LIMIT", "6"))
+# Recovery line spoken when the ReAct loop exceeds RECURSION_LIMIT
+# (LLM kept trying tools but never produced a final answer).
+RECURSION_FALLBACK_TEXT = os.environ.get(
+    "AGENT_TOOL_FALLBACK_TEXT",
+    "うまくできませんでした、すみません。",
+)
+# Suffix appended to AGENT_SYSTEM_PROMPT *only when tools are enabled* so we
+# don't tell the LLM about tools that aren't wired. The phrasing matches the
+# voice-agent persona (タメ口 / 短文 / TTS 向き). Override entirely with
+# AGENT_TOOL_SYSTEM_SUFFIX if you want different guidance.
+TOOL_SYSTEM_SUFFIX = os.environ.get(
+    "AGENT_TOOL_SYSTEM_SUFFIX",
+    " 使える機能があるときは自然に使って答えて。"
+    "機能が失敗したら別の方法を試して、それでも無理なら正直に「できなかった」と伝えて。",
+)
 
 
 class SessionManager:
@@ -107,11 +137,14 @@ class SessionManager:
             return self.current_session
 
 
-def build_graph(llm: ChatOllama, checkpointer: AsyncSqliteSaver):
-    """Single-node chat graph.
+def build_legacy_graph(llm: ChatOllama, checkpointer: AsyncSqliteSaver):
+    """Single-node chat graph (pre-tools fallback).
 
-    The system prompt is injected at LLM-invoke time from the
-    env-configured constant, *not* persisted in state. Two reasons:
+    Kept verbatim from the original implementation so AGENT_TOOLS_ENABLED=false
+    deployments behave exactly as before issue #19.
+
+    The system prompt is injected at LLM-invoke time from the env-configured
+    constant, *not* persisted in state. Two reasons:
 
     1. Restarting the agent with a new `AGENT_SYSTEM_PROMPT` should
        take effect on existing sessions' next turn. If we persisted
@@ -142,6 +175,32 @@ def build_graph(llm: ChatOllama, checkpointer: AsyncSqliteSaver):
     return builder.compile(checkpointer=checkpointer)
 
 
+def build_react_graph(llm: ChatOllama, checkpointer: AsyncSqliteSaver):
+    """ReAct (agent_node ↔ tools) graph for AGENT_TOOLS_ENABLED=true.
+
+    `create_react_agent` handles tool binding, the agent-vs-tools router,
+    and the loop back to agent_node after each tool result. We only
+    customise the prompt (system prompt + tool-usage guidance) so the
+    voice-agent persona is preserved while the LLM learns it has tools.
+
+    Tools live in `tools.py::all_tools()`. Adding one there + entering
+    its name in `TOOL_ACK_PHRASES` is enough to wire it — no changes
+    needed here.
+    """
+    tools = all_tools()
+    prompt = (SYSTEM_PROMPT + TOOL_SYSTEM_SUFFIX) if SYSTEM_PROMPT else TOOL_SYSTEM_SUFFIX.strip()
+    # `prompt=` is injected as a SystemMessage on every LLM call, same
+    # pattern as the legacy graph — i.e. not persisted in state. So
+    # restarting with a different AGENT_SYSTEM_PROMPT still takes effect
+    # on the next turn.
+    return create_react_agent(
+        llm,
+        tools,
+        prompt=prompt,
+        checkpointer=checkpointer,
+    )
+
+
 def extract_user_text(body: dict) -> str:
     """Pluck the last `role:user` content from an ollama-compatible
     /api/chat body.
@@ -164,27 +223,81 @@ def extract_user_text(body: dict) -> str:
 
 async def stream_chat(graph, sessions: SessionManager, user_text: str
                       ) -> AsyncIterator[dict]:
+    """Drive the graph for one turn and yield ndjson-shaped chunks.
+
+    Three sources of LLM-side AIMessageChunk are interleaved when tools
+    are on (one only, when tools are off):
+
+      1. plain content tokens          → forward as `message.content` delta
+      2. tool-call deltas              → DROP (TTS-ing structured JSON
+                                          would be gibberish). Side
+                                          effect: emit a one-shot ack
+                                          chunk on the *first* time we
+                                          see each new tool name so the
+                                          user hears a filler line
+                                          while the tool runs.
+      3. ToolMessage (tool result)     → not an AIMessageChunk; the
+                                          isinstance() filter drops it.
+
+    `recursion_limit` caps the agent→tools→agent loop count per turn.
+    On overflow we yield `RECURSION_FALLBACK_TEXT` as the final spoken
+    line — better than leaving the speaker silent.
+    """
     session_id = await sessions.claim()
-    config = {"configurable": {"thread_id": session_id}}
+    config = {
+        "configurable": {"thread_id": session_id},
+        "recursion_limit": RECURSION_LIMIT,
+    }
     input_state = {"messages": [HumanMessage(content=user_text)]}
-    # stream_mode="messages" yields (message_chunk, metadata) tuples
-    # for every LLM token chunk — exactly what we need to forward
-    # delta-by-delta to the orchestrator's existing ndjson parser.
-    async for chunk, _meta in graph.astream(
-        input_state, config=config, stream_mode="messages"
-    ):
-        # `chunk.content` is `str` for plain text streams (today's
-        # ChatOllama output), but newer langchain message types can
-        # surface a `list[ContentBlock]` for multimodal / tool-call
-        # deltas. The orchestrator's parser expects a string, so we
-        # only forward str chunks — once tools are bound the list
-        # branch will need its own handling.
-        if (
-            isinstance(chunk, AIMessageChunk)
-            and isinstance(chunk.content, str)
-            and chunk.content
+
+    # Tracks the most recent tool name we've spoken an ack for. Reset
+    # per-call (= per-turn) so a fresh turn re-acks. Two consecutive
+    # tool calls of *different* names within the same turn each get
+    # their own ack; two of the *same* name don't re-ack (rare and
+    # would feel repetitive on the speaker).
+    last_acked_tool: str | None = None
+
+    try:
+        async for chunk, _meta in graph.astream(
+            input_state, config=config, stream_mode="messages"
         ):
-            yield {"message": {"content": chunk.content}, "done": False}
+            if not isinstance(chunk, AIMessageChunk):
+                # ToolMessage / SystemMessage etc — not for TTS.
+                continue
+
+            # Tool-call delta: each partial chunk lists 1+ tool_call_chunks
+            # whose `name` may be partial early on (Ollama streams it
+            # token-by-token). We only emit ack when a *complete* known
+            # tool name appears in TOOL_ACK_PHRASES — partial names like
+            # "get_" will simply miss the dict lookup and skip.
+            if chunk.tool_call_chunks:
+                for tc in chunk.tool_call_chunks:
+                    name = tc.get("name")
+                    if name and name != last_acked_tool:
+                        ack = TOOL_ACK_PHRASES.get(name)
+                        if ack:
+                            yield {"message": {"content": ack}, "done": False}
+                        last_acked_tool = name
+                # Suppress the structured-data delta itself.
+                continue
+
+            # `chunk.content` is `str` for plain text streams (today's
+            # ChatOllama output). Newer message types could surface a
+            # `list[ContentBlock]` for multimodal — we ignore those
+            # because the orchestrator's parser expects str.
+            if isinstance(chunk.content, str) and chunk.content:
+                yield {"message": {"content": chunk.content}, "done": False}
+    except GraphRecursionError:
+        # ReAct loop ran past `recursion_limit` without producing a
+        # final assistant message — e.g., the LLM kept calling a tool
+        # that kept failing. Speak the fallback line so the user isn't
+        # left wondering whether the agent crashed.
+        log.warning(
+            "recursion limit %d reached for session %s; emitting fallback",
+            RECURSION_LIMIT, session_id,
+        )
+        yield {"message": {"content": RECURSION_FALLBACK_TEXT}, "done": False}
+
     yield {"done": True}
 
 
@@ -212,7 +325,9 @@ async def chat_handler(request: web.Request) -> web.StreamResponse:
     # raises, the generator's `async for` propagates the cancel, and
     # the LangGraph astream is dropped — which closes ChatOllama's
     # httpx connection to ollama and stops token generation upstream.
-    # No explicit cancellation plumbing needed.
+    # With tools enabled, asyncio-native tool implementations get the
+    # same CancelledError so subprocess.kill() / aiohttp.close() fire
+    # automatically. No explicit cancellation plumbing needed.
     resp = web.StreamResponse(
         status=200,
         headers={"Content-Type": "application/x-ndjson"},
@@ -258,6 +373,7 @@ async def session_handler(request: web.Request) -> web.Response:
             "session_id": sessions.current_session,
             "idle_sec": round(now - sessions.last_active, 2),
             "rotate_after_sec": sessions.idle_seconds,
+            "tools_enabled": TOOLS_ENABLED,
         })
 
 
@@ -269,8 +385,8 @@ async def amain() -> None:
     )
 
     log.info(
-        "agent: ollama=%s model=%s db=%s",
-        OLLAMA_BASE_URL, MODEL_NAME, DB_PATH,
+        "agent: ollama=%s model=%s db=%s tools=%s recursion_limit=%d",
+        OLLAMA_BASE_URL, MODEL_NAME, DB_PATH, TOOLS_ENABLED, RECURSION_LIMIT,
     )
 
     # ChatOllama streams tokens from ollama via httpx. temperature=0
@@ -293,7 +409,7 @@ async def amain() -> None:
     saver = AsyncSqliteSaver(conn)
     await saver.setup()
 
-    graph = build_graph(llm, saver)
+    graph = build_react_graph(llm, saver) if TOOLS_ENABLED else build_legacy_graph(llm, saver)
     sessions = SessionManager(SESSION_IDLE_SEC)
 
     app = web.Application()

--- a/agent/app.py
+++ b/agent/app.py
@@ -92,8 +92,14 @@ RECURSION_FALLBACK_TEXT = os.environ.get(
 # AGENT_TOOL_SYSTEM_SUFFIX if you want different guidance.
 TOOL_SYSTEM_SUFFIX = os.environ.get(
     "AGENT_TOOL_SYSTEM_SUFFIX",
-    " 使える機能があるときは自然に使って答えて。"
-    "機能が失敗したら別の方法を試して、それでも無理なら正直に「できなかった」と伝えて。",
+    " You have tools available — use them naturally when they help."
+    " Tool results are private to you; the user can't see or hear them,"
+    " so don't refer to them with deictic words like 'this', 'these',"
+    " or 'as written there' — instead, restate the relevant content in"
+    " your own words and speak it out. When asked for a list, pick a few"
+    " representative items and name them (you don't have to read"
+    " everything). If a tool fails, try a different approach; if that"
+    " still doesn't work, honestly say you couldn't do it.",
 )
 
 

--- a/agent/app.py
+++ b/agent/app.py
@@ -90,16 +90,58 @@ RECURSION_FALLBACK_TEXT = os.environ.get(
 # don't tell the LLM about tools that aren't wired. The phrasing matches the
 # voice-agent persona (タメ口 / 短文 / TTS 向き). Override entirely with
 # AGENT_TOOL_SYSTEM_SUFFIX if you want different guidance.
-TOOL_SYSTEM_SUFFIX = os.environ.get(
-    "AGENT_TOOL_SYSTEM_SUFFIX",
+# Empty string (not just unset) also falls back to the default. compose.yaml
+# passes the env through with an empty fallback (`${VAR:-}`) so the container
+# always sees the var; without `or`, a blank .env would silently disable the
+# entire tool-use prompt.
+TOOL_SYSTEM_SUFFIX = os.environ.get("AGENT_TOOL_SYSTEM_SUFFIX") or (
     " You have tools available — use them naturally when they help."
     " Tool results are private to you; the user can't see or hear them,"
     " so don't refer to them with deictic words like 'this', 'these',"
     " or 'as written there' — instead, restate the relevant content in"
     " your own words and speak it out. When asked for a list, pick a few"
     " representative items and name them (you don't have to read"
-    " everything). If a tool fails, try a different approach; if that"
-    " still doesn't work, honestly say you couldn't do it.",
+    " everything)."
+    # --- Override the 1-2 sentence brevity rule for the tool-using path.
+    # The base system prompt is tuned for chit-chat; multi-step requests
+    # (find → check → act) need room to run several tool calls in a
+    # single turn without speaking between them. Observed failure: model
+    # said "じゃあ中身見てみるよ" and ended the turn, leaving the task
+    # half-done.
+    " The 1-2 sentence limit in the base prompt applies only to your"
+    " final spoken reply once the task is done. While you're working,"
+    " call as many tools as you need — silently. Do NOT announce intent"
+    " (\"I'll check X\", \"まず~してみるよ\") and then stop the turn."
+    " If you say you'll do something, the next thing in the same turn"
+    " must be the tool call that does it, not the end of your response."
+    # --- Step further: don't bounce questions back the user can't answer
+    # any better than you can.
+    " Before asking the user a clarifying question, check whether you"
+    " can answer it yourself with a tool — today's date (use run_shell"
+    " `date`), what files exist in a directory (`ls`), the contents of"
+    " a file (read_file). Only ask the user about things only they know"
+    " (their intent, their preference, ambiguous wording)."
+    # --- Pre-action checklist for file/audio paths. Reduces the
+    # \"relative path → tool failure\" loop we saw in production.
+    " When acting on a file or directory: first establish the absolute"
+    " path (combine the share root with the relative path the user"
+    " referred to), then confirm the file or directory exists with"
+    " `ls`, then perform the action. Don't guess a path and call the"
+    " action tool hoping it works."
+    # --- Hypothesize-and-retry instead of giving up on the first error.
+    " If a tool returns `[error]` or `[denied]`, form one hypothesis"
+    " about the cause (wrong path? relative instead of absolute? typo"
+    " in filename?) and retry with a corrected input once before"
+    " telling the user it failed. Don't loop more than 2-3 times on"
+    " the same tool — if that doesn't work, honestly say you couldn't"
+    " do it."
+    # --- Tiny CoT nudge. We don't have explicit thinking tokens for
+    # Gemma so this is the prompt-level equivalent.
+    " For requests that involve multiple steps (find a file, then play"
+    " it; look something up, then act on it), briefly plan the steps"
+    " in your head before calling the first tool, then execute all"
+    " the steps in one turn — only speak to the user once everything"
+    " is done (or you've genuinely hit a wall)."
 )
 
 

--- a/agent/app.py
+++ b/agent/app.py
@@ -77,17 +77,22 @@ DB_PATH = os.environ.get("AGENT_DB_PATH", "/data/agent.sqlite")
 SESSION_IDLE_SEC = float(os.environ.get("AGENT_SESSION_IDLE_SEC", "600"))
 PORT = int(os.environ.get("AGENT_PORT", "7080"))
 
-# Feature flag for issue #19. Default off so this PR is a no-op for
-# anyone who doesn't opt in.
+# Feature flag for issue #19. The in-code default is off so a bare
+# `import app` with no env set stays a no-op, but compose.yaml passes
+# AGENT_TOOLS_ENABLED=true — deployed stacks therefore run with tools
+# ON by default (set it false in .env to fall back to the legacy
+# single-node chat graph).
 TOOLS_ENABLED = os.environ.get("AGENT_TOOLS_ENABLED", "false").lower() in ("1", "true", "yes")
 # Caps the number of graph steps per turn (agent_node → tools → agent_node
 # → ... ). 6 ≈ 3 tool calls in a chain. Beyond this we surface a fallback
 # voice line rather than loop forever. issue #19 オープン項目 #6 の retry
 # リミット。
 RECURSION_LIMIT = int(os.environ.get("AGENT_TOOL_RECURSION_LIMIT", "6"))
-# Recovery line spoken when the ReAct loop exceeds RECURSION_LIMIT
-# (LLM kept trying tools but never produced a final answer).
-RECURSION_FALLBACK_TEXT = os.environ.get(
+# Recovery line spoken whenever a turn would otherwise end with no
+# spoken text — either the ReAct loop exceeded RECURSION_LIMIT, or the
+# stream finished after a failed/denied tool without the LLM producing
+# any reply. A voice agent must always say *something*.
+FALLBACK_TEXT = os.environ.get(
     "AGENT_TOOL_FALLBACK_TEXT",
     "うまくできませんでした、すみません。",
 )
@@ -293,7 +298,7 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
                                           isinstance() filter drops it.
 
     `recursion_limit` caps the agent→tools→agent loop count per turn.
-    On overflow we yield `RECURSION_FALLBACK_TEXT` as the final spoken
+    On overflow we yield `FALLBACK_TEXT` as the final spoken
     line — better than leaving the speaker silent.
     """
     session_id = await sessions.claim()
@@ -313,7 +318,7 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
     # Whether any *real* LLM-produced text was yielded (acks don't count).
     # If a turn ends with this still False — e.g. the LLM called a tool,
     # got back a `[denied]` ToolMessage, and silently stopped without
-    # generating an apology — we emit `RECURSION_FALLBACK_TEXT` at the
+    # generating an apology — we emit `FALLBACK_TEXT` at the
     # end so the operator never hears total silence. Observed with
     # gemma4:e4b when allowlist-rejected shell commands feed back.
     real_content_yielded = False
@@ -373,7 +378,7 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
             "recursion limit %d reached for session %s; emitting fallback",
             RECURSION_LIMIT, session_id,
         )
-        yield {"message": {"content": RECURSION_FALLBACK_TEXT}, "done": False}
+        yield {"message": {"content": FALLBACK_TEXT}, "done": False}
         real_content_yielded = True
 
     if not real_content_yielded and last_tool_succeeded is not True:
@@ -388,7 +393,7 @@ async def stream_chat(graph, sessions: SessionManager, user_text: str
             "no LLM text yielded for session %s; emitting fallback",
             session_id,
         )
-        yield {"message": {"content": RECURSION_FALLBACK_TEXT}, "done": False}
+        yield {"message": {"content": FALLBACK_TEXT}, "done": False}
 
     yield {"done": True}
 

--- a/agent/experiments/chat_repl.py
+++ b/agent/experiments/chat_repl.py
@@ -31,6 +31,13 @@ import sys
 import urllib.error
 import urllib.request
 
+# `input()` を readline 経由にして、↑↓ で履歴・←→ でカーソル移動・Ctrl-A/E
+# などの行編集が効くようにする。import するだけで Python の `input()` が
+# 自動的に readline 経由になる (副作用ベースの API)。本 REPL は agent
+# (linux container) 内で `docker compose exec` 経由でしか動かさない前提
+# なので readline は確実に存在する。
+import readline  # noqa: F401
+
 # 1 ターンの応答に最大これだけ待つ。tool 呼び出しが連鎖すると数秒かかるので
 # 余裕を持って 120s。voice agent 本番は recursion_limit + 各 tool timeout で
 # 物理的に上限が決まる。
@@ -62,6 +69,13 @@ def chat_once(url: str, message: str) -> None:
         data=body,
         headers={"Content-Type": "application/json"},
     )
+    # `got_content` / `saw_done`: agent から content も done も来ずに stream
+    # が閉じた場合に「agent からの応答が空でした」と明示するためのフラグ。
+    # これが無いと、REPL は次の `user> ` を `agent> ` と同じ行に貼り付けて
+    # しまい、何が起きたか分かりにくくなる (実観測: tool エラー後に LLM が
+    # 一文字も生成せず close するケース)。
+    got_content = False
+    saw_done = False
     try:
         with urllib.request.urlopen(req, timeout=RESPONSE_TIMEOUT_S) as resp:
             for raw_line in resp:
@@ -75,18 +89,26 @@ def chat_once(url: str, message: str) -> None:
                     sys.stdout.write(f"\n[non-json] {line!r}\n")
                     continue
                 if msg.get("done"):
-                    sys.stdout.write("\n")
-                    sys.stdout.flush()
-                    return
+                    saw_done = True
+                    break
                 content = (msg.get("message") or {}).get("content", "")
                 if content:
+                    got_content = True
                     sys.stdout.write(content)
                     sys.stdout.flush()
     except urllib.error.HTTPError as e:
         body = e.read().decode(errors="replace")
-        sys.stdout.write(f"\n[HTTP {e.code}] {body[:400]}\n")
+        sys.stdout.write(f"\n[HTTP {e.code}] {body[:400]}")
     except Exception as e:  # noqa: BLE001
-        sys.stdout.write(f"\n[client error] {type(e).__name__}: {e}\n")
+        sys.stdout.write(f"\n[client error] {type(e).__name__}: {e}")
+
+    # `agent> ` プロンプトを必ず改行で閉じる。content が無くても (= LLM が
+    # 何も生成せずに終わった or 接続が途中で切れた) 次のユーザプロンプトが
+    # 同じ行に出てしまう問題を防ぐ。
+    if not got_content:
+        sys.stdout.write("(no response)" if saw_done else "(stream closed)")
+    sys.stdout.write("\n")
+    sys.stdout.flush()
 
 
 def main() -> int:

--- a/agent/experiments/chat_repl.py
+++ b/agent/experiments/chat_repl.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""agent /api/chat を叩く最小 CLI REPL (issue #19 step 2 のテストハーネス).
+
+本番の voice pipeline (orchestrator → tts-streamer → audio-io) を通さずに
+agent 単体を CLI で連続会話できるようにするためのスクリプト。tool 呼び出しの
+挙動を目視確認したり、system prompt の効きを試したりするのに使う。
+
+agent 側の wire format (ollama-compat ndjson stream) と接続経路は orchestrator
+が叩くものと同一なので、ここで動けば voice 経由でも動く (はず)。
+
+依存は stdlib のみ — `python3 chat_repl.py` で動く。
+
+使い方:
+    python3 agent/experiments/chat_repl.py
+    python3 agent/experiments/chat_repl.py --url http://localhost:7080
+
+セッションの conversation memory は agent 側 SqliteSaver が持っている。
+連続会話の中で「さっきの話」を引き継げるか確認するときはそのまま続けて
+入力する。Ctrl-D / Ctrl-C で終了。
+
+`--session` (= GET /session) を確認することで現在の thread_id と idle 時間が
+取れる。tools 有効/無効 (= AGENT_TOOLS_ENABLED) もここに出るので、間違った
+agent に向けていないかの一次切り分けに使える。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+# 1 ターンの応答に最大これだけ待つ。tool 呼び出しが連鎖すると数秒かかるので
+# 余裕を持って 120s。voice agent 本番は recursion_limit + 各 tool timeout で
+# 物理的に上限が決まる。
+RESPONSE_TIMEOUT_S = 120
+
+
+def session_info(url: str) -> dict:
+    """GET /session — 起動直後の sanity check に使う。"""
+    with urllib.request.urlopen(f"{url}/session", timeout=5) as resp:
+        return json.loads(resp.read())
+
+
+def chat_once(url: str, message: str) -> None:
+    """1 ターン分の往復。stdout に token を逐次 flush しながら書き出す。
+
+    レスポンスは ollama-compat ndjson (`{"message":{"content":...},"done":false}\n` ×
+    N + `{"done":true}\n`)。urllib のレスポンスオブジェクトは行イテレータと
+    して使えるので別途 buffering ロジックは要らない。
+    """
+    body = json.dumps(
+        {
+            "model": "agent",  # agent 側は body.model を見ない
+            "messages": [{"role": "user", "content": message}],
+            "stream": True,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"{url}/api/chat",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=RESPONSE_TIMEOUT_S) as resp:
+            for raw_line in resp:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    # 想定外の行はそのまま見せる (デバッグ用)。
+                    sys.stdout.write(f"\n[non-json] {line!r}\n")
+                    continue
+                if msg.get("done"):
+                    sys.stdout.write("\n")
+                    sys.stdout.flush()
+                    return
+                content = (msg.get("message") or {}).get("content", "")
+                if content:
+                    sys.stdout.write(content)
+                    sys.stdout.flush()
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        sys.stdout.write(f"\n[HTTP {e.code}] {body[:400]}\n")
+    except Exception as e:  # noqa: BLE001
+        sys.stdout.write(f"\n[client error] {type(e).__name__}: {e}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--url",
+        default="http://localhost:7080",
+        help="agent base URL (default: http://localhost:7080)",
+    )
+    args = parser.parse_args()
+
+    # 起動直後のヘルス確認 — 接続先が間違ってると入力受けてから初めて気付くのを
+    # 防ぐ。tools 有効/無効も表示してテストの一次切り分けに使う。
+    try:
+        info = session_info(args.url)
+    except Exception as e:  # noqa: BLE001
+        print(f"failed to reach {args.url}: {e}", file=sys.stderr)
+        return 1
+    print(f"agent: {args.url}")
+    print(
+        f"session={info.get('session_id', '?')[:8]}  "
+        f"tools_enabled={info.get('tools_enabled', '?')}  "
+        f"idle={info.get('idle_sec', '?')}s"
+    )
+    print("Ctrl-D or Ctrl-C to exit.")
+    print()
+
+    while True:
+        try:
+            text = input("user> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+        if not text:
+            continue
+        sys.stdout.write("agent> ")
+        sys.stdout.flush()
+        chat_once(args.url, text)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/experiments/tool_calling_probe.py
+++ b/agent/experiments/tool_calling_probe.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Gemma 4 + Ollama の tool-calling サポートを 3 ケースで確認する最小プローブ。
+
+issue #19 (agent 拡充) で LangGraph の `create_react_agent` 路線が成立するかは
+モデルが Ollama の `tools=[...]` を理解して `message.tool_calls` を返せるかに
+依存する。本スクリプトは agent コンテナや langchain を経由せず、Ollama の
+/api/chat を直接叩いて以下を判定する:
+
+  1. 引数なし tool を発火できるか      (`get_current_date`)
+  2. 引数を抽出して tool を発火できるか (`add(a, b)`)
+  3. tool 不要時に発火しないか         ("こんにちは")
+
+実行 (ホスト側):
+    python3 agent/experiments/tool_calling_probe.py
+環境変数で上書き可:
+    OLLAMA_URL=http://localhost:7050  (デフォルト)
+    OLLAMA_MODEL=gemma4:e4b           (デフォルト)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:7050").rstrip("/")
+MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e4b")
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_current_date",
+            "description": "現在の日付を YYYY-MM-DD 形式で返す。日付や曜日を聞かれたときに呼ぶ。",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add",
+            "description": "2 つの整数を足し算して結果を返す。算数の計算を聞かれたときに呼ぶ。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer", "description": "1 つ目の整数"},
+                    "b": {"type": "integer", "description": "2 つ目の整数"},
+                },
+                "required": ["a", "b"],
+            },
+        },
+    },
+]
+
+PROBES = [
+    ("引数なし tool 発火",   "今日の日付を教えて。",          ["get_current_date"]),
+    ("引数あり tool 発火",   "3 と 5 を足したらいくつ？",     ["add"]),
+    ("tool 不要 (false-positive 検査)", "こんにちは、元気？", []),
+]
+
+
+def chat(user_text: str) -> dict:
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": user_text}],
+        "tools": TOOLS,
+        "stream": False,
+        "options": {"temperature": 0},
+    }
+    req = urllib.request.Request(
+        f"{OLLAMA_URL}/api/chat",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def summarize(resp: dict) -> tuple[list[str], str]:
+    """Return (tool_call_names, assistant_text)."""
+    msg = resp.get("message") or {}
+    tool_calls = msg.get("tool_calls") or []
+    names = []
+    for tc in tool_calls:
+        fn = tc.get("function") or {}
+        name = fn.get("name", "?")
+        args = fn.get("arguments")
+        names.append(f"{name}({args})" if args else name)
+    return names, (msg.get("content") or "").strip()
+
+
+def main() -> int:
+    print(f"Probing {OLLAMA_URL} model={MODEL}\n")
+    all_ok = True
+    for label, prompt, expected_tools in PROBES:
+        print(f"--- {label} ---")
+        print(f"user: {prompt}")
+        try:
+            resp = chat(prompt)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode(errors="replace")
+            print(f"  HTTP {e.code}: {body[:400]}")
+            all_ok = False
+            continue
+        except Exception as e:  # noqa: BLE001
+            print(f"  ERROR: {type(e).__name__}: {e}")
+            all_ok = False
+            continue
+
+        names, text = summarize(resp)
+        print(f"  tool_calls: {names if names else '(none)'}")
+        if text:
+            print(f"  content:    {text[:200]}")
+
+        if expected_tools:
+            ok = any(any(n.startswith(t) for n in names) for t in expected_tools)
+            verdict = "OK" if ok else "FAIL (no tool_call)"
+        else:
+            ok = not names
+            verdict = "OK" if ok else "FAIL (unexpected tool_call)"
+        print(f"  => {verdict}\n")
+        if not ok:
+            all_ok = False
+
+    print("ALL OK" if all_ok else "SOME PROBES FAILED")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -4,3 +4,11 @@ langgraph>=0.2
 langchain-core>=0.3
 langchain-ollama>=0.2
 langgraph-checkpoint-sqlite>=2.0
+# issue #19 step 3 — web_search tool. DDG はキー不要で TOS が voice agent
+# のユースケースを許容する。rate limit はあるが偶発的失敗は ToolMessage を
+# LLM に渡して「諦めて謝る」経路で吸収する。
+#
+# 旧パッケージ `duckduckgo-search` は 2025 年中に `ddgs` へリネームされた。
+# 旧名で import すると deprecation warning + 検索が空になる挙動だったので
+# 新名のみを採用する。
+ddgs>=9.0

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,14 +1,20 @@
-aiohttp>=3.9
-aiosqlite>=0.20
-langgraph>=0.2
-langchain-core>=0.3
-langchain-ollama>=0.2
-langgraph-checkpoint-sqlite>=2.0
-# issue #19 step 3 — web_search tool. DDG はキー不要で TOS が voice agent
+# 直接依存はピン留め。`docker build` 時に PyPI 最新が紛れ込んで挙動が変わる
+# のを防ぐ。バージョン更新は手動で確認してから `==` の右辺を書き換える。
+# 動作確認時のスタック: gemma4:e4b + ollama 0.23.2 + LangGraph 1.2 系。
+#
+# 注: 推移的依存 (langchain, httpx, primp など) は pip の解決に委ねる。
+# 完全再現が必要になったら pip-tools / uv lock を導入する。
+aiohttp==3.13.5
+aiosqlite==0.22.1
+langgraph==1.2.0
+langchain-core==1.4.0
+langchain-ollama==1.1.0
+langgraph-checkpoint-sqlite==3.1.0
+# issue #19 step 3 — web_search tool。DDG はキー不要で TOS が voice agent
 # のユースケースを許容する。rate limit はあるが偶発的失敗は ToolMessage を
 # LLM に渡して「諦めて謝る」経路で吸収する。
 #
 # 旧パッケージ `duckduckgo-search` は 2025 年中に `ddgs` へリネームされた。
 # 旧名で import すると deprecation warning + 検索が空になる挙動だったので
 # 新名のみを採用する。
-ddgs>=9.0
+ddgs==9.14.2

--- a/agent/sandbox.py
+++ b/agent/sandbox.py
@@ -1,0 +1,92 @@
+"""Sandbox helpers for tool 入力検証 (issue #19).
+
+Pure functions — no I/O, no env reads, no async. tools.py が env から
+allowlist / root を読み込んでこれらに渡すという責務分離。テストが書きやすく、
+ヘルパ単体の不変条件を pin できる。
+
+設計判断:
+* allowlist 違反 / root 脱出は `ValueError` サブクラスで raise する。
+  `create_react_agent` のデフォルト error handling (handle_tool_errors=True)
+  は例外メッセージを ToolMessage として LLM に返すので、LLM が「別のコマンドで
+  retry する」「諦めて謝る」を recursion_limit の範囲で判断できる。
+* shell allowlist は **コマンド名のみ** で照合 (issue #19 オープン項目 #2
+  で確定)。引数 regex まで縛る粒度は導入しない — 危険 API (rm/curl/sh など)
+  をそもそも入れない運用で十分。
+* path は `Path.resolve(strict=False)` で symlink を辿った後の絶対パスで
+  root と比較。`relative_to` の例外を `PathOutsideRoot` に再 raise する。
+  strict=False は「存在しないパス」も resolve できるよう (存在判定は
+  別段で `.is_file()` する)。
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+
+class SandboxError(ValueError):
+    """Base class. ValueError 派生にしておくと LangChain の tool error
+    ハンドラが素直に拾って LLM に message を渡す。"""
+
+
+class CommandNotAllowed(SandboxError):
+    """run_shell の allowlist 違反。"""
+
+
+class PathOutsideRoot(SandboxError):
+    """read_file の root 配下脱出 (symlink 経由を含む)。"""
+
+
+def parse_shell_command(command: str) -> list[str]:
+    """shlex.split で argv に分解。`shell=True` を使わない (=パイプ・
+    リダイレクト・複合コマンドが構造的に不可能) ための前処理。
+
+    空コマンドは `CommandNotAllowed` で弾く — `create_subprocess_exec`
+    に空 argv を渡すと OSError になるので、その前にメッセージ性のある
+    例外で raise した方が LLM が retry 時に状況を理解しやすい。
+    """
+    parts = shlex.split(command)
+    if not parts:
+        raise CommandNotAllowed("empty command")
+    return parts
+
+
+def ensure_command_allowed(command: str, allowlist: set[str]) -> list[str]:
+    """argv に分解し、`argv[0]` が allowlist にあるか確認する。
+
+    OK なら argv (list[str]) を返す。NG なら `CommandNotAllowed`。
+    `allowlist` は呼び出し側で env から読み込んで set 化する想定。
+    完全一致のみ — prefix マッチや regex はサポートしない (粒度を下げる
+    と「rm」も「rmdir」も通る等の罠が生じる)。
+    """
+    argv = parse_shell_command(command)
+    cmd_name = argv[0]
+    if cmd_name not in allowlist:
+        raise CommandNotAllowed(
+            f"command not allowed: {cmd_name!r} "
+            f"(allowed: {sorted(allowlist)})"
+        )
+    return argv
+
+
+def ensure_path_in_root(path: str, root: str) -> Path:
+    """`path` を `root` からの相対パスとして解釈し、resolve 後も `root`
+    配下に収まることを確認した上で絶対 Path を返す。
+
+    LLM には「root 配下の相対パスを渡す」前提で tool を提供しているが、
+    `..` や絶対パスや symlink でその外を覗こうとされても弾けるよう、
+    resolve() 結果と root.resolve() を比較する。
+    """
+    if not path:
+        raise PathOutsideRoot("empty path")
+    root_resolved = Path(root).resolve()
+    # path が絶対パスでも、root を抜けようとすれば下の relative_to で弾ける。
+    # 相対パスは root に対して join した上で resolve する。
+    candidate = (root_resolved / path).resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as e:
+        raise PathOutsideRoot(
+            f"path outside file root: {path!r} (root={str(root_resolved)!r})"
+        ) from e
+    return candidate

--- a/agent/test_sandbox.py
+++ b/agent/test_sandbox.py
@@ -1,0 +1,127 @@
+"""sandbox.py の不変条件を pin する単体テスト。
+
+stdlib unittest を使用 (新規依存追加なし)。run_shell / read_file 本体は
+async + I/O なので別途。ここは pure 関数の入出力だけ検証する。
+
+実行:
+    cd agent && python -m unittest test_sandbox -v
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from sandbox import (
+    CommandNotAllowed,
+    PathOutsideRoot,
+    ensure_command_allowed,
+    ensure_path_in_root,
+    parse_shell_command,
+)
+
+ALLOW = {"date", "ip", "uname", "df", "uptime", "who"}
+
+
+class ParseShellCommandTests(unittest.TestCase):
+    def test_simple(self):
+        self.assertEqual(parse_shell_command("date"), ["date"])
+
+    def test_with_args(self):
+        self.assertEqual(parse_shell_command("uname -a"), ["uname", "-a"])
+
+    def test_quoted(self):
+        # shlex は quote をきちんと処理する — argv[0] が "date" になる。
+        self.assertEqual(parse_shell_command('date "+%Y"'), ["date", "+%Y"])
+
+    def test_empty_raises(self):
+        with self.assertRaises(CommandNotAllowed):
+            parse_shell_command("")
+
+    def test_whitespace_only_raises(self):
+        with self.assertRaises(CommandNotAllowed):
+            parse_shell_command("   ")
+
+
+class EnsureCommandAllowedTests(unittest.TestCase):
+    def test_allowed(self):
+        self.assertEqual(ensure_command_allowed("date", ALLOW), ["date"])
+        self.assertEqual(ensure_command_allowed("uptime", ALLOW), ["uptime"])
+
+    def test_allowed_with_args(self):
+        # 引数は素通し (粒度はコマンド名のみ、issue #19 オープン項目 #2)。
+        self.assertEqual(
+            ensure_command_allowed("uname -a", ALLOW),
+            ["uname", "-a"],
+        )
+
+    def test_denied_simple(self):
+        with self.assertRaises(CommandNotAllowed) as ctx:
+            ensure_command_allowed("rm -rf /", ALLOW)
+        self.assertIn("rm", str(ctx.exception))
+
+    def test_denied_path_disguised(self):
+        # フルパスを与えても allowlist には "/bin/date" は無いので NG。
+        # 完全一致照合の効用 (prefix マッチだと "date" のせいで通っちゃう)。
+        with self.assertRaises(CommandNotAllowed):
+            ensure_command_allowed("/bin/date", ALLOW)
+
+    def test_denied_substring_safe(self):
+        # "rmdir" が allowlist に入っていても "rm" は別物として扱う。
+        allow_with_rmdir = ALLOW | {"rmdir"}
+        with self.assertRaises(CommandNotAllowed):
+            ensure_command_allowed("rm -rf /", allow_with_rmdir)
+
+
+class EnsurePathInRootTests(unittest.TestCase):
+    def setUp(self):
+        # 各テストごとに使い捨ての root ディレクトリを作る。
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name).resolve()
+        # OK ターゲット: root/sub/data.txt
+        (self.root / "sub").mkdir()
+        (self.root / "sub" / "data.txt").write_text("hello")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_relative_ok(self):
+        p = ensure_path_in_root("sub/data.txt", str(self.root))
+        self.assertEqual(p, self.root / "sub" / "data.txt")
+
+    def test_root_self(self):
+        # 空文字列は弾く (空 path 経由で root そのものを返してしまうのを防ぐ)。
+        with self.assertRaises(PathOutsideRoot):
+            ensure_path_in_root("", str(self.root))
+
+    def test_absolute_outside_denied(self):
+        with self.assertRaises(PathOutsideRoot):
+            ensure_path_in_root("/etc/passwd", str(self.root))
+
+    def test_dotdot_traversal_denied(self):
+        with self.assertRaises(PathOutsideRoot):
+            ensure_path_in_root("../etc/passwd", str(self.root))
+
+    def test_dotdot_deep_traversal_denied(self):
+        with self.assertRaises(PathOutsideRoot):
+            ensure_path_in_root("sub/../../etc/passwd", str(self.root))
+
+    def test_symlink_jailbreak_denied(self):
+        # root 内の symlink が root 外を指すケース — resolve() 後に
+        # relative_to が ValueError を上げて弾けることを確認。これが
+        # `Path.resolve()` を必ず通す動機。
+        outside = Path(tempfile.mkdtemp())
+        try:
+            (outside / "secret.txt").write_text("secret")
+            (self.root / "link").symlink_to(outside / "secret.txt")
+            with self.assertRaises(PathOutsideRoot):
+                ensure_path_in_root("link", str(self.root))
+        finally:
+            (outside / "secret.txt").unlink()
+            outside.rmdir()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -1,0 +1,50 @@
+"""LangChain tool 定義 + ack phrase マッピング (issue #19).
+
+各 tool は `@tool` デコレータで LangChain Tool に変換され、agent_node に
+`create_react_agent` 経由でバインドされる。LLM (Gemma 4) は description を
+読んで「いつどの tool を呼ぶか」を確率的に判断する — コード側はルーティング
+するだけで判断には関与しない (詳細は issue #19 設計コメント参照)。
+
+ack phrase は tool 実行中の無音をカバーする目的の合成 chunk。`TOOL_ACK_PHRASES`
+で tool 名 → 文字列にマップし、None なら ack 挿入をスキップする (即応 tool 向け)。
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone, timedelta
+
+from langchain_core.tools import tool
+
+# 日本標準時。voice agent は日本語前提で動くので JST 固定が自然。海外向けに
+# 切り出すときは TZ env を見るように変える。
+JST = timezone(timedelta(hours=9))
+
+
+@tool
+def get_current_datetime() -> str:
+    """現在の日時を JST で ISO 8601 形式 (例: 2026-05-13T15:30:00+09:00) で返す。
+
+    日付・時刻・曜日・今が何月か・現在年などを聞かれたときに呼ぶ。
+    """
+    return datetime.now(JST).isoformat(timespec="seconds")
+
+
+def all_tools() -> list:
+    """登録 tool の一覧。`create_react_agent` に渡す。
+
+    issue #19 の段階的な追加に伴い後段の PR で `run_shell` / `read_file` /
+    `web_search` / `list_drive_files` / `read_drive_file` が積まれる予定。
+    """
+    return [get_current_datetime]
+
+
+# tool name → ack phrase。None なら ack 挿入なし。
+#
+# 即応 tool (date / shell / file) は None でよく、遅い tool (web 検索や Drive
+# アクセス) だけ ack を入れて voice agent の無音を埋める。文言は環境変数で
+# 上書き可能にしておくと運用しやすい — 各 tool 単位の ack 環境変数は対応する
+# tool が wire された PR で追加する。
+TOOL_ACK_PHRASES: dict[str, str | None] = {
+    "get_current_datetime": None,
+}

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import audioop  # Python 3.13 で deprecated だが、stdlib のままで動く間は依存ゼロで便利。
+import difflib
 import json
 import logging
 import os
@@ -290,11 +291,35 @@ async def _play_audio_file_impl(path: str) -> str:
         raise RuntimeError(
             "AGENT_AUDIO_IO_SPK_URL is not set — audio playback is disabled"
         )
+    # 相対パスを許容する: read_file と意味論を合わせて _FILE_ROOT 配下として
+    # 解釈し、root 外脱出は弾く。LLM が `ls` で見た相対パスをそのまま渡して
+    # きても再生できるようにする (実運用での誤り頻度が高かったため)。
     p = Path(path)
     if not p.is_absolute():
-        raise ValueError(f"path must be absolute, got: {path!r}")
+        if not _FILE_ROOT:
+            raise ValueError(
+                f"path must be absolute, got: {path!r} "
+                "(AGENT_FILE_ROOT not set so relative paths cannot be resolved)"
+            )
+        p = ensure_path_in_root(path, _FILE_ROOT)
     if not p.is_file():
-        raise FileNotFoundError(f"not a file: {path}")
+        # 似た名前のファイルを同じ親ディレクトリから 5 件まで返す。
+        # LLM が「該当ファイルが無い → このリストの中から選び直す or
+        # 諦めて user に伝える」と判断できるようにするための補助情報。
+        # 親ディレクトリ自体が無いケースも想定して try/except で包む。
+        hint = ""
+        try:
+            parent = p.parent
+            if parent.is_dir():
+                names = [c.name for c in parent.iterdir() if c.is_file()]
+                close = difflib.get_close_matches(p.name, names, n=5, cutoff=0.4)
+                if close:
+                    hint = f" (did you mean: {', '.join(close)})"
+                elif names:
+                    hint = f" (files in {parent}: {', '.join(sorted(names)[:5])})"
+        except OSError:
+            pass
+        raise FileNotFoundError(f"not a file: {p}{hint}")
 
     # WAV パース + リサンプル / リミックスは sync I/O + CPU 仕事なので
     # まとめて thread にオフロード。圧縮 / sample width は raise する
@@ -429,15 +454,22 @@ def _build_play_audio_description() -> str:
             "that audio playback is not configured here so they know the "
             "limit is on the setup, not on their request."
         )
+    path_hint = (
+        f"`path` is a WAV file path. Either absolute (e.g. `/workspace/share/foo.wav`) "
+        f"or relative to the share root `{_FILE_ROOT}` (e.g. `share/foo.wav`)."
+        if _FILE_ROOT
+        else "`path` is an **absolute** filesystem path to a WAV file."
+    )
     return (
         "Play a WAV audio file via the speaker.\n\n"
-        "`path` is an **absolute** filesystem path to a WAV file. The file "
-        "must be uncompressed 16-bit PCM (s16le). Sample rate and channel "
-        "count are auto-converted to "
+        f"{path_hint} The file must be uncompressed 16-bit PCM (s16le). "
+        "Sample rate and channel count are auto-converted to "
         f"{_AUDIO_IO_WIRE_RATE}Hz / {_AUDIO_IO_WIRE_CHANNELS} channel(s) "
         "(audio-io's wire format) if they differ, so 44.1kHz stereo and "
-        "48kHz mono and similar are all accepted. Relative paths, "
-        "compressed WAVs, and >2-channel surround formats are rejected.\n\n"
+        "48kHz mono and similar are all accepted. Compressed WAVs and "
+        ">2-channel surround formats are rejected. If the file isn't "
+        "found, the error message lists similar filenames in the same "
+        "directory — pick one and retry rather than asking the user.\n\n"
         "Call this when the user asks to play a specific audio file — "
         "for example a pre-rendered news summary or notification produced "
         "by another agent. The tool blocks until playback completes; if "

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -14,20 +14,29 @@ ack phrase は tool 実行中の無音をカバーする目的の合成 chunk。
   やリダイレクトは構造的に不可能。
 * `read_file` は env `AGENT_FILE_ROOT` 配下の **相対パス** のみ受け付ける。
   `Path.resolve()` で symlink 経由の jailbreak も弾く。
-* 違反は `sandbox.SandboxError` (ValueError 派生) で raise → LangChain が
-  ToolMessage として LLM に渡し、retry / 諦めを LLM 自身に判断させる
-  (recursion_limit で打ち切り)。
+
+エラーハンドリング:
+* tool 内部の例外は全て catch し `[denied] ...` / `[error] ...` 文字列として
+  return する。raise すると LangChain が必ずしも捕捉しきれず、AIMessage の
+  tool_calls が state に残ったまま対応 ToolMessage が積まれず以降のターンが
+  INVALID_CHAT_HISTORY で死ぬ (検証で確認済)。string return にすれば LLM が
+  「失敗した、別の方法を試す or 諦める」を ToolMessage を読んで判断できる。
+* allowlist 違反のように LLM が retry しても無意味な失敗は `[denied]` プレ
+  フィックスで区別し、LLM が「無理だから諦めて答える」方に倒しやすくする。
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from datetime import datetime, timezone, timedelta
 
 from langchain_core.tools import tool
 
-from sandbox import ensure_command_allowed, ensure_path_in_root
+from sandbox import SandboxError, ensure_command_allowed, ensure_path_in_root
+
+log = logging.getLogger("agent.tools")
 
 # 日本標準時。voice agent は日本語前提で動くので JST 固定が自然。海外向けに
 # 切り出すときは TZ env を見るように変える。
@@ -66,17 +75,9 @@ def get_current_datetime() -> str:
     return datetime.now(JST).isoformat(timespec="seconds")
 
 
-@tool
-async def run_shell(command: str) -> str:
-    """Linux のシェルコマンドを 1 つ実行して標準出力を返す。
-
-    許可されたコマンド名のみ実行できる (例: date, uptime, df, uname, ip, who)。
-    パイプ (`|`) やリダイレクト (`>`)、複数コマンドの連結 (`;`, `&&`) は使えない。
-    日付・ネットワーク状況・ディスク使用量・カーネル情報などを調べるときに呼ぶ。
-
-    引数 command にはコマンド本体と引数をスペース区切りで渡す
-    (例: `"uname -a"`, `"df -h"`, `"ip addr"`)。
-    """
+async def _run_shell_impl(command: str) -> str:
+    """run_shell の本体。例外は raise する — `run_shell` 側で catch して
+    文字列化する。テスト容易性のため `@tool` ラッパとは分離している。"""
     argv = ensure_command_allowed(command, _SHELL_ALLOWLIST)
     proc = await asyncio.create_subprocess_exec(
         *argv,
@@ -113,17 +114,21 @@ async def run_shell(command: str) -> str:
 
 
 @tool
-async def read_file(path: str) -> str:
-    """指定ファイルを読んで内容をそのまま返す。
+async def run_shell(command: str) -> str:
+    """Linux のシェルコマンドを 1 つ実行して標準出力を返す。
 
-    path は `AGENT_FILE_ROOT` (= 共有ディレクトリ) からの相対パスを渡す
-    (例: `"memo.txt"`, `"docs/recipe.md"`)。絶対パスや `..` を含むパスは
-    拒否される。
+    許可されたコマンド名のみ実行できる (例: date, uptime, df, uname, ip, who)。
+    パイプ (`|`) やリダイレクト (`>`)、複数コマンドの連結 (`;`, `&&`) は使えない。
+    日付・ネットワーク状況・ディスク使用量・カーネル情報などを調べるときに呼ぶ。
 
-    voice agent のユースケース: ユーザに「メモを読んで」「あのファイルを
-    読んで」と言われたとき、ここで内容を取得して読み上げに繋げる。
-    内容は 50 KB を超える場合は末尾が省略される。
+    引数 command にはコマンド本体と引数をスペース区切りで渡す
+    (例: `"uname -a"`, `"df -h"`, `"ip addr"`)。
     """
+    return await _safe_invoke("run_shell", _run_shell_impl(command))
+
+
+async def _read_file_impl(path: str) -> str:
+    """read_file の本体。例外は raise する — `read_file` 側で catch する。"""
     if not _FILE_ROOT:
         raise RuntimeError(
             "AGENT_FILE_ROOT is not configured — read_file is disabled"
@@ -140,6 +145,47 @@ async def read_file(path: str) -> str:
     if truncated:
         text += "\n[...truncated]"
     return text
+
+
+@tool
+async def read_file(path: str) -> str:
+    """指定ファイルを読んで内容をそのまま返す。
+
+    path は `AGENT_FILE_ROOT` (= 共有ディレクトリ) からの相対パスを渡す
+    (例: `"memo.txt"`, `"docs/recipe.md"`)。絶対パスや `..` を含むパスは
+    拒否される。
+
+    voice agent のユースケース: ユーザに「メモを読んで」「あのファイルを
+    読んで」と言われたとき、ここで内容を取得して読み上げに繋げる。
+    内容は 50 KB を超える場合は末尾が省略される。
+    """
+    return await _safe_invoke("read_file", _read_file_impl(path))
+
+
+async def _safe_invoke(name: str, coro) -> str:
+    """共通エラーハンドラ。tool 本体 (coroutine) を await し、例外は文字列化
+    して返す。
+
+    raise すると LangChain v0.3 系の create_react_agent が AIMessage の
+    tool_calls を state に積んだまま ToolMessage を積まないことがあり、以降の
+    ターンで INVALID_CHAT_HISTORY (Found AIMessages with tool_calls that do
+    not have a corresponding ToolMessage) で全 chat が死ぬ。本関数で string に
+    変換しておけば、ReAct ループが必ず ToolMessage を state に積むので state
+    が壊れない。
+
+    `SandboxError` は LLM が retry しても通らない設定/権限系なので
+    `[denied]` プレフィックスで明示し、LLM が「諦めて答える」方向に倒れやすく
+    する (system prompt の「無理なら正直に伝えて」と組合せる)。それ以外は
+    `[error]` で retry-worth な扱いに。
+    """
+    try:
+        return await coro
+    except SandboxError as e:
+        log.info("tool %s denied: %s", name, e)
+        return f"[denied] {e}"
+    except Exception as e:  # noqa: BLE001
+        log.warning("tool %s failed: %s: %s", name, type(e).__name__, e)
+        return f"[error] {type(e).__name__}: {e}"
 
 
 # --- tool 登録 ----------------------------------------------------------

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -83,12 +83,19 @@ def get_current_datetime() -> str:
 
 async def _run_shell_impl(command: str) -> str:
     """run_shell の本体。例外は raise する — `run_shell` 側で catch して
-    文字列化する。テスト容易性のため `@tool` ラッパとは分離している。"""
+    文字列化する。テスト容易性のため `@tool` ラッパとは分離している。
+
+    cwd は `_FILE_ROOT` (set されていれば) に揃える。`read_file` が
+    `_FILE_ROOT` 相対のパスを取るのと意味論を合わせ、LLM が `ls` / `cat`
+    を引数なし or 相対パスで呼んだときに同じ場所を見るようにする
+    (未設定なら inherited = `/app`、agent 本体のコードが見える点は現状維持)。
+    """
     argv = ensure_command_allowed(command, _SHELL_ALLOWLIST)
     proc = await asyncio.create_subprocess_exec(
         *argv,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        cwd=_FILE_ROOT or None,
     )
     try:
         stdout_b, stderr_b = await asyncio.wait_for(
@@ -136,13 +143,22 @@ def _build_run_shell_description() -> str:
         avail = f"許可されているコマンド名は **{listed}** のみ"
     else:
         avail = "現在は何も許可されていない (AGENT_SHELL_ALLOWLIST が空)"
+    cwd_hint = (
+        f"カレントディレクトリは `{_FILE_ROOT}` (= read_file のルート)。"
+        "相対パスで呼ぶとこの配下を見る (例: `ls`, `cat memo.txt`)。"
+        "他の場所を見たいときは絶対パスを渡す (例: `ls /etc`)。"
+        if _FILE_ROOT
+        else "カレントディレクトリは agent コンテナの `/app`。"
+        "ファイルを指定するときは絶対パスを渡す (例: `ls /etc`)。"
+    )
     return (
         "Linux のシェルコマンドを 1 つ実行して標準出力を返す。\n\n"
         f"{avail}。これ以外を渡すと [denied] エラーが返る。\n"
         "パイプ (`|`)、リダイレクト (`>`)、複数コマンドの連結 (`;`, `&&`) は"
         "構造的に使えない (`shell=True` 不使用)。\n\n"
+        f"{cwd_hint}\n\n"
         "command にはコマンド本体と引数をスペース区切りで渡す "
-        "(例: `\"date\"`, `\"ls /workspace\"`)。実行は 5 秒で打ち切られ、"
+        "(例: `\"date\"`, `\"ls\"`)。実行は 5 秒で打ち切られ、"
         "stdout は 3KB を超えると末尾省略される。"
     )
 

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -119,17 +119,38 @@ async def _run_shell_impl(command: str) -> str:
     return result
 
 
-@tool
-async def run_shell(command: str) -> str:
-    """Linux のシェルコマンドを 1 つ実行して標準出力を返す。
+def _build_run_shell_description() -> str:
+    """Tool description を `_SHELL_ALLOWLIST` から動的に組み立てる。
 
-    許可されたコマンド名のみ実行できる (例: date, uptime, df, uname, ip, who)。
-    パイプ (`|`) やリダイレクト (`>`)、複数コマンドの連結 (`;`, `&&`) は使えない。
-    日付・ネットワーク状況・ディスク使用量・カーネル情報などを調べるときに呼ぶ。
+    `@tool` デコレータ呼び出し時に評価して LangChain の tool schema に
+    入れる。これで LLM は **実際にこの環境で許可されているコマンド名** を
+    把握でき、`.env` で allowlist を上書きしても LLM の手元の説明が古い
+    まま (`ls` を呼ぶと「unknown command」と思い込む) という mismatch が
+    起きない。
 
-    引数 command にはコマンド本体と引数をスペース区切りで渡す
-    (例: `"uname -a"`, `"df -h"`, `"ip addr"`)。
+    env を変えたら agent コンテナを restart する必要があるのは現状と同じ
+    (`_SHELL_ALLOWLIST` 自体が module load 時 1 回読みなので)。
     """
+    if _SHELL_ALLOWLIST:
+        listed = ", ".join(sorted(_SHELL_ALLOWLIST))
+        avail = f"許可されているコマンド名は **{listed}** のみ"
+    else:
+        avail = "現在は何も許可されていない (AGENT_SHELL_ALLOWLIST が空)"
+    return (
+        "Linux のシェルコマンドを 1 つ実行して標準出力を返す。\n\n"
+        f"{avail}。これ以外を渡すと [denied] エラーが返る。\n"
+        "パイプ (`|`)、リダイレクト (`>`)、複数コマンドの連結 (`;`, `&&`) は"
+        "構造的に使えない (`shell=True` 不使用)。\n\n"
+        "command にはコマンド本体と引数をスペース区切りで渡す "
+        "(例: `\"date\"`, `\"ls /workspace\"`)。実行は 5 秒で打ち切られ、"
+        "stdout は 3KB を超えると末尾省略される。"
+    )
+
+
+@tool(description=_build_run_shell_description())
+async def run_shell(command: str) -> str:
+    # docstring ではなく @tool(description=...) で description を渡している。
+    # 詳細は `_build_run_shell_description` の docstring 参照。
     return await _safe_invoke("run_shell", _run_shell_impl(command))
 
 

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -28,9 +28,14 @@ ack phrase は tool 実行中の無音をカバーする目的の合成 chunk。
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+import time
+import wave
+from pathlib import Path
 
+import aiohttp
 from langchain_core.tools import tool
 
 from sandbox import SandboxError, ensure_command_allowed, ensure_path_in_root
@@ -50,12 +55,33 @@ _SHELL_ALLOWLIST: set[str] = {
 # read_file 自体が「未設定」エラーで raise (= tool が事実上 disabled)。
 _FILE_ROOT: str = os.environ.get("AGENT_FILE_ROOT", "")
 
+# play_audio_file: audio-io の /spk WebSocket URL (track 番号も含む)。
+# 例: ws://host.docker.internal:7010/spk?track=1
+# 空なら tool の description が「現在使用不可」と LLM に伝え、呼ばれても
+# 即 [error] で返す。
+_AUDIO_IO_SPK_URL: str = os.environ.get("AGENT_AUDIO_IO_SPK_URL", "")
+# audio-io の wire format。WAV のサンプルレート / チャンネル数がこれと
+# 一致しない場合は再生を拒否する (一致しないまま送ると framer が誤解釈
+# して早回し / 遅回しの音が出るため)。defaults はプロジェクト標準。
+_AUDIO_IO_WIRE_RATE: int = int(os.environ.get("AGENT_AUDIO_IO_WIRE_RATE", "16000"))
+_AUDIO_IO_WIRE_CHANNELS: int = int(os.environ.get("AGENT_AUDIO_IO_WIRE_CHANNELS", "1"))
+# 単一再生の壁時計上限 (秒)。1 時間の WAV をうっかり渡されると tool が
+# その間 block するので DoS 対策。
+_AUDIO_PLAY_MAX_S: float = float(os.environ.get("AGENT_AUDIO_PLAY_MAX_S", "300"))
+
 # 出力サイズ上限 (issue #19 設計の「個別 tool ごと truncate」決定に基づく)。
 _SHELL_STDOUT_MAX = 3000
 _FILE_READ_MAX = 51200  # 50 KB
 _WEB_SEARCH_MAX_RESULTS = 5      # top-N 件
 _WEB_SEARCH_SNIPPET_MAX = 120    # 各件 snippet の文字数上限
 _WEB_SEARCH_TOTAL_MAX = 1500     # 全体上限 (≈ context 圧迫を避ける)
+# audio-io へ送る 1 batch (= 1 WS message) の長さ。20ms は audio-io の
+# 既定の frame_ms と合わせている。これより細かいと WS のオーバーヘッドが
+# 増え、これより粗いと barge-in (途中停止) のレスポンスが鈍る。
+_AUDIO_PLAY_FRAME_MS = 20
+# {"type":"eos"} を投げた後 {"type":"drained"} を待つ最大時間。長尾の
+# 最終文 (~30s) でも drain 完了するよう余裕をもたせる。
+_AUDIO_DRAIN_TIMEOUT_S = 30.0
 
 # subprocess の壁時計タイムアウト。voice agent としては即応が前提なので
 # 短めに切る。長く回したい操作は run_shell のスコープ外。
@@ -245,6 +271,153 @@ async def web_search(query: str) -> str:
     return await _safe_invoke("web_search", _web_search_impl(query))
 
 
+async def _play_audio_file_impl(path: str) -> str:
+    """play_audio_file 本体。audio-io の /spk (?track=N) WS に PCM を realtime
+    ペーシングで流し、`{"type":"eos"}` で drain handshake して終わる。
+
+    全例外は `_safe_invoke` で string 化される。barge-in は orchestrator が
+    /api/chat の HTTP を切ることで `asyncio.CancelledError` を伝播させて
+    アボートする — その時点で `async with` の context manager が WS を閉じ、
+    audio-io 側もリングが drain → close を見て後始末する。
+    """
+    if not _AUDIO_IO_SPK_URL:
+        raise RuntimeError(
+            "AGENT_AUDIO_IO_SPK_URL is not set — audio playback is disabled"
+        )
+    p = Path(path)
+    if not p.is_absolute():
+        raise ValueError(f"path must be absolute, got: {path!r}")
+    if not p.is_file():
+        raise FileNotFoundError(f"not a file: {path}")
+
+    # WAV パースは sync I/O なので thread にオフロード。WAV 形式の検証も
+    # ここで一括 (チャンネル数 / レート / 圧縮 / 長さ / sample width)。
+    def _read_wav() -> tuple[bytes, int, int, int]:
+        with wave.open(str(p), "rb") as wav:
+            comp = wav.getcomptype()
+            if comp != "NONE":
+                raise ValueError(
+                    f"compressed WAV ({comp}) is not supported; "
+                    "give uncompressed PCM (s16le)"
+                )
+            sw = wav.getsampwidth()
+            if sw != 2:
+                raise ValueError(
+                    f"unsupported sample width {sw * 8} bits; "
+                    "only 16-bit PCM (s16le) is supported"
+                )
+            fr = wav.getframerate()
+            ch = wav.getnchannels()
+            if fr != _AUDIO_IO_WIRE_RATE:
+                raise ValueError(
+                    f"sample rate {fr}Hz does not match audio-io wire "
+                    f"rate {_AUDIO_IO_WIRE_RATE}Hz — re-render the WAV to "
+                    f"{_AUDIO_IO_WIRE_RATE}Hz first"
+                )
+            if ch != _AUDIO_IO_WIRE_CHANNELS:
+                raise ValueError(
+                    f"channels {ch} does not match audio-io wire channels "
+                    f"{_AUDIO_IO_WIRE_CHANNELS}"
+                )
+            n = wav.getnframes()
+            duration_s = n / fr
+            if duration_s > _AUDIO_PLAY_MAX_S:
+                raise ValueError(
+                    f"duration {duration_s:.1f}s exceeds limit "
+                    f"{_AUDIO_PLAY_MAX_S:.0f}s"
+                )
+            return wav.readframes(n), n, ch, fr
+
+    pcm, nframes, nchannels, framerate = await asyncio.to_thread(_read_wav)
+    bytes_per_sample = 2 * nchannels
+    samples_per_frame = framerate * _AUDIO_PLAY_FRAME_MS // 1000
+    bytes_per_frame = samples_per_frame * bytes_per_sample
+    duration_s = nframes / framerate
+
+    log.info(
+        "play_audio_file: %s (%.1fs, %dHz, %dch) → %s",
+        p.name, duration_s, framerate, nchannels, _AUDIO_IO_SPK_URL,
+    )
+
+    # ws_connect の sock_connect で接続フェーズを短く (audio-io が居なければ
+    # ここで即落ちて [error] にする)。全体 timeout は意図的に None — 長尺
+    # 再生中ずっと send/recv するので。
+    client_timeout = aiohttp.ClientTimeout(total=None, sock_connect=10.0)
+    async with aiohttp.ClientSession(timeout=client_timeout) as session:
+        async with session.ws_connect(_AUDIO_IO_SPK_URL) as ws:
+            start = time.monotonic()
+            frame_idx = 0
+            offset = 0
+            while offset < len(pcm):
+                chunk = pcm[offset : offset + bytes_per_frame]
+                offset += len(chunk)
+                # audio-io は奇数バイトの WS frame を拒否する (s16le なので
+                # 通常は偶数だが、末尾の半端な chunk が来た場合だけパディング)。
+                if len(chunk) % 2 != 0:
+                    chunk = chunk + b"\x00"
+                await ws.send_bytes(chunk)
+                frame_idx += 1
+                # 実時間ペーシング。各 frame は frame_idx * FRAME_MS のタイミングで
+                # 送出する。audio-io 側の ring (deafult 10s) を溢れさせない目的。
+                target = start + frame_idx * _AUDIO_PLAY_FRAME_MS / 1000.0
+                sleep_for = target - time.monotonic()
+                if sleep_for > 0:
+                    await asyncio.sleep(sleep_for)
+            # Drain handshake: eos を送ってから "drained" が戻るまで待つ。
+            # これで audio-io の cpal リングが本当に空になったことが保証される。
+            await ws.send_str(json.dumps({"type": "eos"}))
+            try:
+                msg = await asyncio.wait_for(
+                    ws.receive(), timeout=_AUDIO_DRAIN_TIMEOUT_S
+                )
+                if msg.type != aiohttp.WSMsgType.TEXT:
+                    log.warning(
+                        "play_audio_file: drain reply was %s, not TEXT",
+                        msg.type,
+                    )
+            except asyncio.TimeoutError:
+                log.warning(
+                    "play_audio_file: drain handshake timed out after %.0fs",
+                    _AUDIO_DRAIN_TIMEOUT_S,
+                )
+    return f"played {duration_s:.1f}s from {p.name}"
+
+
+def _build_play_audio_description() -> str:
+    """Tool description を起動時の env (`_AUDIO_IO_SPK_URL` の有無) に応じて
+    動的に生成する。URL 未設定なら「無効」を明示し、LLM が呼ばずに状況を
+    user に伝えるよう誘導する。"""
+    if not _AUDIO_IO_SPK_URL:
+        return (
+            "Play a WAV audio file via the speaker.\n\n"
+            "**CURRENTLY UNAVAILABLE** — the AGENT_AUDIO_IO_SPK_URL env "
+            "is not set, so this feature is disabled in this environment. "
+            "Do NOT call this tool; instead, tell the user in one sentence "
+            "that audio playback is not configured here so they know the "
+            "limit is on the setup, not on their request."
+        )
+    return (
+        "Play a WAV audio file via the speaker.\n\n"
+        "`path` is an **absolute** filesystem path to a WAV file. The file "
+        f"must be uncompressed 16-bit PCM (s16le) at "
+        f"{_AUDIO_IO_WIRE_RATE}Hz with {_AUDIO_IO_WIRE_CHANNELS} channel(s) "
+        "(audio-io's wire format). Relative paths, compressed WAVs, and "
+        "mismatched sample rate / channels are rejected.\n\n"
+        "Call this when the user asks to play a specific audio file — "
+        "for example a pre-rendered news summary or notification produced "
+        "by another agent. The tool blocks until playback completes; if "
+        "the user interrupts via wake-word, playback aborts cleanly. "
+        f"Duration is capped at {_AUDIO_PLAY_MAX_S:.0f} seconds."
+    )
+
+
+@tool(description=_build_play_audio_description())
+async def play_audio_file(path: str) -> str:
+    # description は @tool(description=...) で動的注入。詳細は
+    # `_build_play_audio_description` の docstring を参照。
+    return await _safe_invoke("play_audio_file", _play_audio_file_impl(path))
+
+
 @tool
 async def read_file(path: str) -> str:
     """Read a file and return its contents verbatim.
@@ -293,18 +466,26 @@ def all_tools() -> list:
 
     issue #19 の段階的な追加に伴い後段の PR で別 tool が積まれる可能性あり。
     """
-    return [run_shell, read_file, web_search]
+    return [run_shell, read_file, web_search, play_audio_file]
 
 
 # tool name → ack phrase。None なら ack 挿入なし。
 #
-# 即応 tool (shell / file) は None でよく、遅い tool (web 検索) だけ ack を
-# 入れて voice agent の無音を埋める。文言は環境変数で上書き可能にしておくと
-# 運用しやすい。
+# 即応 tool (shell / file) は None でよく、遅い tool (web 検索 / 音声再生)
+# だけ ack を入れて voice agent の無音を埋める。文言は環境変数で上書き可能。
+#
+# play_audio_file は AGENT_AUDIO_IO_SPK_URL が未設定なら呼び出し即 [error]
+# になるので、その場合は ack も抑止しておく (「再生するね」と言った直後に
+# 失敗を返すと UX が混乱するため)。
 TOOL_ACK_PHRASES: dict[str, str | None] = {
     "run_shell": None,
     "read_file": None,
     "web_search": os.environ.get(
         "AGENT_TOOL_ACK_WEB_SEARCH", "ちょっと検索してみるね。"
+    ),
+    "play_audio_file": (
+        os.environ.get("AGENT_TOOL_ACK_PLAY_AUDIO", "音声を再生するね。")
+        if _AUDIO_IO_SPK_URL
+        else None
     ),
 }

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -28,7 +28,7 @@ ack phrase は tool 実行中の無音をカバーする目的の合成 chunk。
 from __future__ import annotations
 
 import asyncio
-import audioop  # Python 3.13 で deprecated だが、stdlib のままで動く間は依存ゼロで便利。
+import audioop  # 3.11 で deprecated、3.13 で stdlib から削除。3.11 pin の間は依存ゼロで使えるが、base image を上げる際は要置換。
 import difflib
 import json
 import logging
@@ -37,7 +37,7 @@ import sys
 import time
 import wave
 from pathlib import Path
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 import aiohttp
 from langchain_core.tools import tool
@@ -85,10 +85,28 @@ def _derive_stop_url(spk_url: str) -> str:
     scheme は ws→http / wss→https、path 末尾の `/spk` に `/stop` を足し、
     `?track=N` クエリはそのまま引き継ぐ (= play と同じ track を狙い撃ちする)。
     設定を 1 本化するため専用 env は持たず、ここで変換する。
+
+    `?track=N` は必須。未指定だと派生する /spk/stop も track なし = audio-io
+    側で全 track flush (TTS の track 0 まで巻き込む) になってしまうので、起動
+    時にここで明示的に弾く。N は非負整数 (audio-io の track id は 0 始まり)。
     """
     if not spk_url:
         return ""
     parts = urlsplit(spk_url)
+    track_vals = parse_qs(parts.query).get("track")
+    if not track_vals:
+        raise ValueError(
+            f"AGENT_AUDIO_IO_SPK_URL must include a ?track=N query "
+            f"(N >= 0); got {spk_url!r}"
+        )
+    try:
+        track = int(track_vals[0])
+    except ValueError as e:
+        raise ValueError(
+            f"?track= must be an integer, got {track_vals[0]!r} in {spk_url!r}"
+        ) from e
+    if track < 0:
+        raise ValueError(f"?track= must be >= 0, got {track} in {spk_url!r}")
     scheme = {"ws": "http", "wss": "https"}.get(parts.scheme, parts.scheme)
     path = parts.path.rstrip("/")
     # 通常 path は `/spk`。それ以外でも `/stop` を足して壊さないようにする。
@@ -363,18 +381,18 @@ def _read_and_convert_wav(p: Path) -> tuple[bytes, float, int, int]:
 def _resolve_audio_path(path: str) -> Path:
     """play_audio_file の path を解決する。
 
-    相対パスは read_file と意味論を合わせて `_FILE_ROOT` 配下として解釈し、
-    root 外脱出は弾く (LLM が `ls` で見た相対パスをそのまま渡しても再生
-    できるように)。見つからなければ似た名前を最大 5 件 hint に付けて raise。
+    相対パス・絶対パスとも read_file と意味論を合わせて `_FILE_ROOT` 配下に
+    confine する (LLM が `ls` で見た相対パスをそのまま渡しても、絶対パスを
+    渡しても、root 外脱出は弾く)。`ensure_path_in_root` は絶対パスでも join +
+    resolve 後に `relative_to` で判定するので、root 内の絶対パスは通り、外は
+    `PathOutsideRoot` で弾かれる。見つからなければ似た名前を最大 5 件 hint に
+    付けて raise。
     """
-    p = Path(path)
-    if not p.is_absolute():
-        if not _FILE_ROOT:
-            raise ValueError(
-                f"path must be absolute, got: {path!r} "
-                "(AGENT_FILE_ROOT not set so relative paths cannot be resolved)"
-            )
-        p = ensure_path_in_root(path, _FILE_ROOT)
+    if not _FILE_ROOT:
+        raise ValueError(
+            f"cannot resolve audio path {path!r}: AGENT_FILE_ROOT is not set"
+        )
+    p = ensure_path_in_root(path, _FILE_ROOT)
     if not p.is_file():
         # 似た名前のファイルを同じ親ディレクトリから 5 件まで返す。
         # LLM が「該当ファイルが無い → このリストの中から選び直す or
@@ -518,11 +536,14 @@ def _build_play_audio_description() -> str:
             "limit is on the setup, not on their request."
         )
     path_hint = (
-        f"`paths` is a list of WAV file paths. Each is either absolute "
-        f"(e.g. `/workspace/share/foo.wav`) or relative to the share root "
-        f"`{_FILE_ROOT}` (e.g. `share/foo.wav`)."
+        f"`paths` is a list of WAV file paths, each inside the share root "
+        f"`{_FILE_ROOT}`. Give them relative to that root (e.g. "
+        f"`share/foo.wav`) or as an absolute path within it (e.g. "
+        f"`/workspace/share/foo.wav`). Paths outside the root (including "
+        f"via `..` or symlinks) are rejected."
         if _FILE_ROOT
-        else "`paths` is a list of **absolute** filesystem paths to WAV files."
+        else "`paths` is a list of WAV file paths (AGENT_FILE_ROOT is unset, "
+        "so playback is effectively disabled)."
     )
     return (
         "Play one or more WAV audio files via the speaker.\n\n"

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -7,19 +7,55 @@
 
 ack phrase は tool 実行中の無音をカバーする目的の合成 chunk。`TOOL_ACK_PHRASES`
 で tool 名 → 文字列にマップし、None なら ack 挿入をスキップする (即応 tool 向け)。
+
+セキュリティ:
+* `run_shell` は env `AGENT_SHELL_ALLOWLIST` (CSV) で許可コマンド名を完全一致
+  照合。`asyncio.create_subprocess_exec` を使い `shell=True` は禁止 — パイプ
+  やリダイレクトは構造的に不可能。
+* `read_file` は env `AGENT_FILE_ROOT` 配下の **相対パス** のみ受け付ける。
+  `Path.resolve()` で symlink 経由の jailbreak も弾く。
+* 違反は `sandbox.SandboxError` (ValueError 派生) で raise → LangChain が
+  ToolMessage として LLM に渡し、retry / 諦めを LLM 自身に判断させる
+  (recursion_limit で打ち切り)。
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import datetime, timezone, timedelta
 
 from langchain_core.tools import tool
 
+from sandbox import ensure_command_allowed, ensure_path_in_root
+
 # 日本標準時。voice agent は日本語前提で動くので JST 固定が自然。海外向けに
 # 切り出すときは TZ env を見るように変える。
 JST = timezone(timedelta(hours=9))
 
+# --- 環境変数 (起動時に 1 度読む) -------------------------------------------
+
+# `AGENT_SHELL_ALLOWLIST="date,ip,uname,df,uptime,who"` 形式。空白は許容。
+# set 化して O(1) で照合する。空文字列なら空 set = 一切のコマンドを拒否。
+_SHELL_ALLOWLIST: set[str] = {
+    s.strip()
+    for s in os.environ.get("AGENT_SHELL_ALLOWLIST", "").split(",")
+    if s.strip()
+}
+# read_file の root。compose で volume mount したパスをここに指す。空なら
+# read_file 自体が「未設定」エラーで raise (= tool が事実上 disabled)。
+_FILE_ROOT: str = os.environ.get("AGENT_FILE_ROOT", "")
+
+# 出力サイズ上限 (issue #19 設計の「個別 tool ごと truncate」決定に基づく)。
+_SHELL_STDOUT_MAX = 3000
+_FILE_READ_MAX = 51200  # 50 KB
+
+# subprocess の壁時計タイムアウト。voice agent としては即応が前提なので
+# 短めに切る。長く回したい操作は run_shell のスコープ外。
+_SHELL_TIMEOUT_S = 5.0
+
+
+# --- tool 実装 ----------------------------------------------------------
 
 @tool
 def get_current_datetime() -> str:
@@ -30,13 +66,91 @@ def get_current_datetime() -> str:
     return datetime.now(JST).isoformat(timespec="seconds")
 
 
+@tool
+async def run_shell(command: str) -> str:
+    """Linux のシェルコマンドを 1 つ実行して標準出力を返す。
+
+    許可されたコマンド名のみ実行できる (例: date, uptime, df, uname, ip, who)。
+    パイプ (`|`) やリダイレクト (`>`)、複数コマンドの連結 (`;`, `&&`) は使えない。
+    日付・ネットワーク状況・ディスク使用量・カーネル情報などを調べるときに呼ぶ。
+
+    引数 command にはコマンド本体と引数をスペース区切りで渡す
+    (例: `"uname -a"`, `"df -h"`, `"ip addr"`)。
+    """
+    argv = ensure_command_allowed(command, _SHELL_ALLOWLIST)
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(), timeout=_SHELL_TIMEOUT_S
+        )
+    except asyncio.TimeoutError:
+        # SIGKILL してから wait() で zombie 化を防ぐ。barge-in による
+        # CancelledError もここを通って同じ後始末を踏む。
+        proc.kill()
+        await proc.wait()
+        raise TimeoutError(
+            f"command timed out after {_SHELL_TIMEOUT_S:.1f}s: {argv[0]}"
+        )
+    stdout = stdout_b.decode("utf-8", errors="replace")
+    stderr = stderr_b.decode("utf-8", errors="replace")
+    # 結果文字列の組み立て: 終了コード != 0 なら明示、stderr があれば追記。
+    # LLM が「失敗した、別コマンドで retry」と判断できるよう情報を残す。
+    parts: list[str] = []
+    if proc.returncode != 0:
+        parts.append(f"[exit {proc.returncode}]")
+    if stdout:
+        parts.append(stdout)
+    if stderr:
+        parts.append(f"[stderr]\n{stderr}")
+    result = "\n".join(parts) if parts else "(no output)"
+    if len(result) > _SHELL_STDOUT_MAX:
+        result = result[:_SHELL_STDOUT_MAX] + "\n[...truncated]"
+    return result
+
+
+@tool
+async def read_file(path: str) -> str:
+    """指定ファイルを読んで内容をそのまま返す。
+
+    path は `AGENT_FILE_ROOT` (= 共有ディレクトリ) からの相対パスを渡す
+    (例: `"memo.txt"`, `"docs/recipe.md"`)。絶対パスや `..` を含むパスは
+    拒否される。
+
+    voice agent のユースケース: ユーザに「メモを読んで」「あのファイルを
+    読んで」と言われたとき、ここで内容を取得して読み上げに繋げる。
+    内容は 50 KB を超える場合は末尾が省略される。
+    """
+    if not _FILE_ROOT:
+        raise RuntimeError(
+            "AGENT_FILE_ROOT is not configured — read_file is disabled"
+        )
+    resolved = ensure_path_in_root(path, _FILE_ROOT)
+    if not resolved.is_file():
+        raise FileNotFoundError(f"not a file: {path}")
+    # ファイル I/O は asyncio.to_thread でオフロードして event loop の
+    # ブロックを避ける。50 KB なら一瞬だが、ネットワーク FS にマウント
+    # された場合のレイテンシを吸収する保険。
+    data = await asyncio.to_thread(resolved.read_bytes)
+    truncated = len(data) > _FILE_READ_MAX
+    text = data[:_FILE_READ_MAX].decode("utf-8", errors="replace")
+    if truncated:
+        text += "\n[...truncated]"
+    return text
+
+
+# --- tool 登録 ----------------------------------------------------------
+
 def all_tools() -> list:
     """登録 tool の一覧。`create_react_agent` に渡す。
 
-    issue #19 の段階的な追加に伴い後段の PR で `run_shell` / `read_file` /
-    `web_search` / `list_drive_files` / `read_drive_file` が積まれる予定。
+    issue #19 の段階的な追加に伴い後段の PR で `web_search` / `list_drive_files`
+    / `read_drive_file` が積まれる予定。
     """
-    return [get_current_datetime]
+    return [get_current_datetime, run_shell, read_file]
 
 
 # tool name → ack phrase。None なら ack 挿入なし。
@@ -47,4 +161,6 @@ def all_tools() -> list:
 # tool が wire された PR で追加する。
 TOOL_ACK_PHRASES: dict[str, str | None] = {
     "get_current_datetime": None,
+    "run_shell": None,
+    "read_file": None,
 }

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -58,10 +58,16 @@ _FILE_ROOT: str = os.environ.get("AGENT_FILE_ROOT", "")
 # 出力サイズ上限 (issue #19 設計の「個別 tool ごと truncate」決定に基づく)。
 _SHELL_STDOUT_MAX = 3000
 _FILE_READ_MAX = 51200  # 50 KB
+_WEB_SEARCH_MAX_RESULTS = 5      # top-N 件
+_WEB_SEARCH_SNIPPET_MAX = 120    # 各件 snippet の文字数上限
+_WEB_SEARCH_TOTAL_MAX = 1500     # 全体上限 (≈ context 圧迫を避ける)
 
 # subprocess の壁時計タイムアウト。voice agent としては即応が前提なので
 # 短めに切る。長く回したい操作は run_shell のスコープ外。
 _SHELL_TIMEOUT_S = 5.0
+# DDG 検索のタイムアウト。voice agent は即応性が大事なので短め。rate limit
+# でレスポンスが詰まったら諦めて LLM に「失敗」を渡す方が UX が良い。
+_WEB_SEARCH_TIMEOUT_S = 5.0
 
 
 # --- tool 実装 ----------------------------------------------------------
@@ -147,6 +153,64 @@ async def _read_file_impl(path: str) -> str:
     return text
 
 
+async def _web_search_impl(query: str) -> str:
+    """web_search の本体。DDG の sync API を asyncio.to_thread で
+    オフロードしつつ全体を wait_for でラップして 5s で打ち切る。"""
+    query = (query or "").strip()
+    if not query:
+        raise ValueError("query is empty")
+
+    # 遅延 import: ddgs が requirements に無い古い環境でも tools モジュール
+    # 自体は import できるようにしておく (CI のすり抜け検知用)。
+    # 旧パッケージ名 `duckduckgo_search` は 2025 年に `ddgs` にリネーム
+    # されており、旧名で import すると検索が空 list を返す挙動になる。
+    from ddgs import DDGS
+
+    def _do_search() -> list[dict]:
+        # DDGS はコンテキストマネージャ。`text()` は generator/list を返す。
+        # max_results=N を渡せば最初の N 件で打ち切る。
+        with DDGS() as ddgs:
+            return list(ddgs.text(query, max_results=_WEB_SEARCH_MAX_RESULTS))
+
+    results = await asyncio.wait_for(
+        asyncio.to_thread(_do_search),
+        timeout=_WEB_SEARCH_TIMEOUT_S,
+    )
+    if not results:
+        return "(no search results)"
+
+    # 件ごとに title + snippet + href を整形。LLM はこれを context として
+    # 受け取り「要点を口頭でまとめて」読み上げる想定。href は短縮しない —
+    # LLM が引用 URL として言及できる方が voice agent として誠実。
+    parts: list[str] = []
+    for i, r in enumerate(results, start=1):
+        title = (r.get("title") or "").strip()
+        snippet = (r.get("body") or "").strip()
+        href = (r.get("href") or "").strip()
+        if len(snippet) > _WEB_SEARCH_SNIPPET_MAX:
+            snippet = snippet[:_WEB_SEARCH_SNIPPET_MAX] + "…"
+        parts.append(f"{i}. {title}\n   {snippet}\n   {href}")
+    text = "\n".join(parts)
+    if len(text) > _WEB_SEARCH_TOTAL_MAX:
+        text = text[:_WEB_SEARCH_TOTAL_MAX] + "\n[...truncated]"
+    return text
+
+
+@tool
+async def web_search(query: str) -> str:
+    """インターネットを検索して上位 5 件の概要を返す。
+
+    最新ニュース・商品情報・調べごとなど、自分の知識だけでは答えられないことを
+    聞かれたときに呼ぶ。query には自然文の検索クエリを渡す (例:
+    `"今日の東京の天気"`, `"Rust async runtime 比較"`)。
+
+    結果は各件 `N. タイトル / snippet / URL` 形式で最大 5 件、全体 1500 字を
+    超えると末尾省略。リアルタイムページ取得や本文全文は別 tool 範囲外なので、
+    snippet を見て要点を自然な言葉で要約して答える。
+    """
+    return await _safe_invoke("web_search", _web_search_impl(query))
+
+
 @tool
 async def read_file(path: str) -> str:
     """指定ファイルを読んで内容をそのまま返す。
@@ -193,20 +257,23 @@ async def _safe_invoke(name: str, coro) -> str:
 def all_tools() -> list:
     """登録 tool の一覧。`create_react_agent` に渡す。
 
-    issue #19 の段階的な追加に伴い後段の PR で `web_search` / `list_drive_files`
-    / `read_drive_file` が積まれる予定。
+    issue #19 の段階的な追加に伴い後段の PR で `list_drive_files` /
+    `read_drive_file` が積まれる予定。
     """
-    return [get_current_datetime, run_shell, read_file]
+    return [get_current_datetime, run_shell, read_file, web_search]
 
 
 # tool name → ack phrase。None なら ack 挿入なし。
 #
 # 即応 tool (date / shell / file) は None でよく、遅い tool (web 検索や Drive
 # アクセス) だけ ack を入れて voice agent の無音を埋める。文言は環境変数で
-# 上書き可能にしておくと運用しやすい — 各 tool 単位の ack 環境変数は対応する
-# tool が wire された PR で追加する。
+# 上書き可能にしておくと運用しやすい — Drive 系は対応 tool 追加の PR で同様に
+# AGENT_TOOL_ACK_DRIVE などを追加する想定。
 TOOL_ACK_PHRASES: dict[str, str | None] = {
     "get_current_datetime": None,
     "run_shell": None,
     "read_file": None,
+    "web_search": os.environ.get(
+        "AGENT_TOOL_ACK_WEB_SEARCH", "ちょっと検索してみるね。"
+    ),
 }

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -278,22 +278,69 @@ async def web_search(query: str) -> str:
     return await _safe_invoke("web_search", _web_search_impl(query))
 
 
-async def _play_audio_file_impl(path: str) -> str:
-    """play_audio_file 本体。audio-io の /spk (?track=N) WS に PCM を realtime
-    ペーシングで流し、`{"type":"eos"}` で drain handshake して終わる。
+def _read_and_convert_wav(p: Path) -> tuple[bytes, float, int, int]:
+    """単一 WAV を読んで wire format (rate/channels) に揃えた PCM を返す。
 
-    全例外は `_safe_invoke` で string 化される。barge-in は orchestrator が
-    /api/chat の HTTP を切ることで `asyncio.CancelledError` を伝播させて
-    アボートする — その時点で `async with` の context manager が WS を閉じ、
-    audio-io 側もリングが drain → close を見て後始末する。
+    返り値は `(pcm, duration_s, src_rate, src_ch)`。圧縮 / 非 s16le は raise。
+    duration の上限チェックはここではせず、呼び出し側が合計で判定する
+    (複数ファイルの合算で `_AUDIO_PLAY_MAX_S` を超えたら弾くため)。
+    sync I/O + CPU 仕事なので呼び出し側で `asyncio.to_thread` に乗せる。
     """
-    if not _AUDIO_IO_SPK_URL:
-        raise RuntimeError(
-            "AGENT_AUDIO_IO_SPK_URL is not set — audio playback is disabled"
+    with wave.open(str(p), "rb") as wav:
+        comp = wav.getcomptype()
+        if comp != "NONE":
+            raise ValueError(
+                f"compressed WAV ({comp}) is not supported; "
+                "give uncompressed PCM (s16le)"
+            )
+        sw = wav.getsampwidth()
+        if sw != _AUDIO_SAMPLE_WIDTH:
+            raise ValueError(
+                f"unsupported sample width {sw * 8} bits; "
+                "only 16-bit PCM (s16le) is supported"
+            )
+        fr = wav.getframerate()
+        ch = wav.getnchannels()
+        n = wav.getnframes()
+        duration_s = n / fr
+        pcm = wav.readframes(n)
+
+    # チャンネル変換 (audioop は 1↔2 のみネイティブ対応)。
+    # rate 変換より先にやると後段の処理データ量が減るので少しだけ速い。
+    if ch != _AUDIO_IO_WIRE_CHANNELS:
+        if ch == 2 and _AUDIO_IO_WIRE_CHANNELS == 1:
+            pcm = audioop.tomono(pcm, _AUDIO_SAMPLE_WIDTH, 0.5, 0.5)
+        elif ch == 1 and _AUDIO_IO_WIRE_CHANNELS == 2:
+            pcm = audioop.tostereo(pcm, _AUDIO_SAMPLE_WIDTH, 1.0, 1.0)
+        else:
+            raise ValueError(
+                f"cannot convert {ch}-channel WAV to "
+                f"{_AUDIO_IO_WIRE_CHANNELS}-channel wire format "
+                "(only 1↔2 channel conversions are supported)"
+            )
+
+    # サンプルレート変換。`state=None` は新規変換 (連続呼び出し時の
+    # 補間状態を引き継がない) を意味する。各ファイル独立に変換するので None。
+    if fr != _AUDIO_IO_WIRE_RATE:
+        pcm, _ = audioop.ratecv(
+            pcm,
+            _AUDIO_SAMPLE_WIDTH,
+            _AUDIO_IO_WIRE_CHANNELS,
+            fr,
+            _AUDIO_IO_WIRE_RATE,
+            None,
         )
-    # 相対パスを許容する: read_file と意味論を合わせて _FILE_ROOT 配下として
-    # 解釈し、root 外脱出は弾く。LLM が `ls` で見た相対パスをそのまま渡して
-    # きても再生できるようにする (実運用での誤り頻度が高かったため)。
+
+    return pcm, duration_s, fr, ch
+
+
+def _resolve_audio_path(path: str) -> Path:
+    """play_audio_file の path を解決する。
+
+    相対パスは read_file と意味論を合わせて `_FILE_ROOT` 配下として解釈し、
+    root 外脱出は弾く (LLM が `ls` で見た相対パスをそのまま渡しても再生
+    できるように)。見つからなければ似た名前を最大 5 件 hint に付けて raise。
+    """
     p = Path(path)
     if not p.is_absolute():
         if not _FILE_ROOT:
@@ -320,82 +367,72 @@ async def _play_audio_file_impl(path: str) -> str:
         except OSError:
             pass
         raise FileNotFoundError(f"not a file: {p}{hint}")
+    return p
 
-    # WAV パース + リサンプル / リミックスは sync I/O + CPU 仕事なので
-    # まとめて thread にオフロード。圧縮 / sample width は raise する
-    # (audioop は s16le 固定で扱う)。sample rate / channels の不一致は
-    # ここで吸収して wire format に揃える。
-    def _read_wav() -> tuple[bytes, float, int, int]:
-        with wave.open(str(p), "rb") as wav:
-            comp = wav.getcomptype()
-            if comp != "NONE":
+
+async def _play_audio_file_impl(paths: list[str] | str) -> str:
+    """play_audio_file 本体。1 本の audio-io /spk (?track=N) WS に、渡された
+    全 WAV の PCM を順に realtime ペーシングで流し込み、最後に一度だけ
+    `{"type":"eos"}` で drain handshake して終わる (ギャップレス連続再生)。
+
+    全例外は `_safe_invoke` で string 化される。barge-in は orchestrator が
+    /api/chat の HTTP を切ることで `asyncio.CancelledError` を伝播させて
+    アボートする — その時点で `async with` の context manager が WS を閉じ、
+    audio-io 側もリングが drain → close を見て後始末する。これは連続再生の
+    途中でも効くので、複数ファイルでも 1 回の wake-word で全停止できる。
+    """
+    if not _AUDIO_IO_SPK_URL:
+        raise RuntimeError(
+            "AGENT_AUDIO_IO_SPK_URL is not set — audio playback is disabled"
+        )
+    # LLM が単一文字列を渡してくる可能性があるので list に正規化する
+    # (tool スキーマは array だが boundary なので念のため吸収)。
+    if isinstance(paths, str):
+        paths = [paths]
+    if not paths:
+        raise ValueError("no audio file given; pass at least one WAV path")
+
+    # 1 件でも見つからない / 不正なら、再生を一切始める前に弾く。
+    # 連続再生は単一 drain なので、途中で中断するより全件検証してから
+    # 流し始める方が「半分だけ鳴った」状態を避けられる。
+    resolved = [_resolve_audio_path(path) for path in paths]
+
+    # 全ファイルを読んで wire format に揃え、合計 duration で上限を判定する。
+    # WAV パース + リサンプルは sync I/O + CPU 仕事なのでまとめて thread に
+    # オフロード。返すのは連結用の (name, pcm) と、ログ用の変換メモ。
+    def _read_all() -> tuple[list[tuple[str, bytes]], float, list[str]]:
+        clips: list[tuple[str, bytes]] = []
+        total_s = 0.0
+        notes: list[str] = []
+        for p in resolved:
+            pcm, dur, src_rate, src_ch = _read_and_convert_wav(p)
+            total_s += dur
+            if total_s > _AUDIO_PLAY_MAX_S:
                 raise ValueError(
-                    f"compressed WAV ({comp}) is not supported; "
-                    "give uncompressed PCM (s16le)"
-                )
-            sw = wav.getsampwidth()
-            if sw != _AUDIO_SAMPLE_WIDTH:
-                raise ValueError(
-                    f"unsupported sample width {sw * 8} bits; "
-                    "only 16-bit PCM (s16le) is supported"
-                )
-            fr = wav.getframerate()
-            ch = wav.getnchannels()
-            n = wav.getnframes()
-            duration_s = n / fr
-            if duration_s > _AUDIO_PLAY_MAX_S:
-                raise ValueError(
-                    f"duration {duration_s:.1f}s exceeds limit "
+                    f"total duration {total_s:.1f}s exceeds limit "
                     f"{_AUDIO_PLAY_MAX_S:.0f}s"
                 )
-            pcm = wav.readframes(n)
+            clips.append((p.name, pcm))
+            if (src_rate, src_ch) != (_AUDIO_IO_WIRE_RATE, _AUDIO_IO_WIRE_CHANNELS):
+                notes.append(f"{p.name} {src_rate}Hz/{src_ch}ch→wire")
+        return clips, total_s, notes
 
-        # チャンネル変換 (audioop は 1↔2 のみネイティブ対応)。
-        # rate 変換より先にやると後段の処理データ量が減るので少しだけ速い。
-        if ch != _AUDIO_IO_WIRE_CHANNELS:
-            if ch == 2 and _AUDIO_IO_WIRE_CHANNELS == 1:
-                pcm = audioop.tomono(pcm, _AUDIO_SAMPLE_WIDTH, 0.5, 0.5)
-            elif ch == 1 and _AUDIO_IO_WIRE_CHANNELS == 2:
-                pcm = audioop.tostereo(pcm, _AUDIO_SAMPLE_WIDTH, 1.0, 1.0)
-            else:
-                raise ValueError(
-                    f"cannot convert {ch}-channel WAV to "
-                    f"{_AUDIO_IO_WIRE_CHANNELS}-channel wire format "
-                    "(only 1↔2 channel conversions are supported)"
-                )
-
-        # サンプルレート変換。`state=None` は新規変換 (連続呼び出し時の
-        # 補間状態を引き継がない) を意味する。今回は単発なので None で OK。
-        if fr != _AUDIO_IO_WIRE_RATE:
-            pcm, _ = audioop.ratecv(
-                pcm,
-                _AUDIO_SAMPLE_WIDTH,
-                _AUDIO_IO_WIRE_CHANNELS,
-                fr,
-                _AUDIO_IO_WIRE_RATE,
-                None,
-            )
-
-        return pcm, duration_s, fr, ch
-
-    pcm, duration_s, src_rate, src_ch = await asyncio.to_thread(_read_wav)
+    clips, duration_s, notes = await asyncio.to_thread(_read_all)
+    # 連結すると frame 境界が clip 境界をまたぐが、各 clip は wire format で
+    # サンプル境界が揃っているので連結 PCM もそのまま streaming できる
+    # (= ギャップレス)。
+    pcm = b"".join(clip_pcm for _, clip_pcm in clips)
     bytes_per_sample = _AUDIO_SAMPLE_WIDTH * _AUDIO_IO_WIRE_CHANNELS
     samples_per_frame = _AUDIO_IO_WIRE_RATE * _AUDIO_PLAY_FRAME_MS // 1000
     bytes_per_frame = samples_per_frame * bytes_per_sample
 
-    if (src_rate, src_ch) != (_AUDIO_IO_WIRE_RATE, _AUDIO_IO_WIRE_CHANNELS):
-        log.info(
-            "play_audio_file: %s (%.1fs) converted %dHz/%dch → %dHz/%dch → %s",
-            p.name, duration_s, src_rate, src_ch,
-            _AUDIO_IO_WIRE_RATE, _AUDIO_IO_WIRE_CHANNELS,
-            _AUDIO_IO_SPK_URL,
-        )
-    else:
-        log.info(
-            "play_audio_file: %s (%.1fs, %dHz, %dch) → %s",
-            p.name, duration_s, _AUDIO_IO_WIRE_RATE,
-            _AUDIO_IO_WIRE_CHANNELS, _AUDIO_IO_SPK_URL,
-        )
+    names = ", ".join(name for name, _ in clips)
+    convert_note = f" [converted: {'; '.join(notes)}]" if notes else ""
+    log.info(
+        "play_audio_file: %d file(s) (%.1fs total, %dHz/%dch wire) [%s]%s → %s",
+        len(clips), duration_s, _AUDIO_IO_WIRE_RATE, _AUDIO_IO_WIRE_CHANNELS,
+        names, convert_note, _AUDIO_IO_SPK_URL,
+    )
 
     # ws_connect の sock_connect で接続フェーズを短く (audio-io が居なければ
     # ここで即落ちて [error] にする)。全体 timeout は意図的に None — 長尺
@@ -438,7 +475,7 @@ async def _play_audio_file_impl(path: str) -> str:
                     "play_audio_file: drain handshake timed out after %.0fs",
                     _AUDIO_DRAIN_TIMEOUT_S,
                 )
-    return f"played {duration_s:.1f}s from {p.name}"
+    return f"played {duration_s:.1f}s from {len(clips)} file(s): {names}"
 
 
 def _build_play_audio_description() -> str:
@@ -447,7 +484,7 @@ def _build_play_audio_description() -> str:
     user に伝えるよう誘導する。"""
     if not _AUDIO_IO_SPK_URL:
         return (
-            "Play a WAV audio file via the speaker.\n\n"
+            "Play one or more WAV audio files via the speaker.\n\n"
             "**CURRENTLY UNAVAILABLE** — the AGENT_AUDIO_IO_SPK_URL env "
             "is not set, so this feature is disabled in this environment. "
             "Do NOT call this tool; instead, tell the user in one sentence "
@@ -455,34 +492,39 @@ def _build_play_audio_description() -> str:
             "limit is on the setup, not on their request."
         )
     path_hint = (
-        f"`path` is a WAV file path. Either absolute (e.g. `/workspace/share/foo.wav`) "
-        f"or relative to the share root `{_FILE_ROOT}` (e.g. `share/foo.wav`)."
+        f"`paths` is a list of WAV file paths. Each is either absolute "
+        f"(e.g. `/workspace/share/foo.wav`) or relative to the share root "
+        f"`{_FILE_ROOT}` (e.g. `share/foo.wav`)."
         if _FILE_ROOT
-        else "`path` is an **absolute** filesystem path to a WAV file."
+        else "`paths` is a list of **absolute** filesystem paths to WAV files."
     )
     return (
-        "Play a WAV audio file via the speaker.\n\n"
-        f"{path_hint} The file must be uncompressed 16-bit PCM (s16le). "
-        "Sample rate and channel count are auto-converted to "
-        f"{_AUDIO_IO_WIRE_RATE}Hz / {_AUDIO_IO_WIRE_CHANNELS} channel(s) "
-        "(audio-io's wire format) if they differ, so 44.1kHz stereo and "
-        "48kHz mono and similar are all accepted. Compressed WAVs and "
-        ">2-channel surround formats are rejected. If the file isn't "
-        "found, the error message lists similar filenames in the same "
-        "directory — pick one and retry rather than asking the user.\n\n"
-        "Call this when the user asks to play a specific audio file — "
+        "Play one or more WAV audio files via the speaker.\n\n"
+        f"{path_hint} Pass several paths to play them back-to-back, "
+        "gapless, in the given order within a single call. Each file must "
+        "be uncompressed 16-bit PCM (s16le). Sample rate and channel count "
+        f"are auto-converted to {_AUDIO_IO_WIRE_RATE}Hz / "
+        f"{_AUDIO_IO_WIRE_CHANNELS} channel(s) (audio-io's wire format) if "
+        "they differ, so 44.1kHz stereo and 48kHz mono and similar are all "
+        "accepted. Compressed WAVs and >2-channel surround formats are "
+        "rejected. All paths are validated before playback starts, so if "
+        "any file is missing nothing plays; the error message lists similar "
+        "filenames in the same directory — pick one and retry rather than "
+        "asking the user.\n\n"
+        "Call this when the user asks to play specific audio file(s) — "
         "for example a pre-rendered news summary or notification produced "
         "by another agent. The tool blocks until playback completes; if "
         "the user interrupts via wake-word, playback aborts cleanly. "
-        f"Duration is capped at {_AUDIO_PLAY_MAX_S:.0f} seconds."
+        f"Total duration across all files is capped at {_AUDIO_PLAY_MAX_S:.0f} "
+        "seconds."
     )
 
 
 @tool(description=_build_play_audio_description())
-async def play_audio_file(path: str) -> str:
+async def play_audio_file(paths: list[str]) -> str:
     # description は @tool(description=...) で動的注入。詳細は
     # `_build_play_audio_description` の docstring を参照。
-    return await _safe_invoke("play_audio_file", _play_audio_file_impl(path))
+    return await _safe_invoke("play_audio_file", _play_audio_file_impl(paths))
 
 
 @tool
@@ -573,6 +615,7 @@ TOOL_ACK_PHRASES: dict[str, str | None] = {
 #
 # 例:
 #   python tools.py play_audio_file /workspace/share/foo.wav
+#   python tools.py play_audio_file share/a.wav share/b.wav   # 連続再生
 #   python tools.py run_shell command="ls -la"
 def _cli_list(tools: list) -> None:
     print("available tools:")
@@ -634,7 +677,12 @@ async def _cli_main(argv: list[str]) -> int:
         _cli_show(tool_obj)
         return 0
 
-    args = _cli_parse(argv[1:], list((tool_obj.args or {}).keys()))
+    if name == "play_audio_file":
+        # `paths` は list なので汎用の positional zip では扱えない。
+        # 残り argv を全部まとめて 1 つの list として渡す。
+        args = {"paths": argv[1:]}
+    else:
+        args = _cli_parse(argv[1:], list((tool_obj.args or {}).keys()))
     result = await tool_obj.ainvoke(args)
     print(result)
     return 0

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -30,17 +30,12 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from datetime import datetime, timezone, timedelta
 
 from langchain_core.tools import tool
 
 from sandbox import SandboxError, ensure_command_allowed, ensure_path_in_root
 
 log = logging.getLogger("agent.tools")
-
-# 日本標準時。voice agent は日本語前提で動くので JST 固定が自然。海外向けに
-# 切り出すときは TZ env を見るように変える。
-JST = timezone(timedelta(hours=9))
 
 # --- 環境変数 (起動時に 1 度読む) -------------------------------------------
 
@@ -71,15 +66,9 @@ _WEB_SEARCH_TIMEOUT_S = 5.0
 
 
 # --- tool 実装 ----------------------------------------------------------
-
-@tool
-def get_current_datetime() -> str:
-    """現在の日時を JST で ISO 8601 形式 (例: 2026-05-13T15:30:00+09:00) で返す。
-
-    日付・時刻・曜日・今が何月か・現在年などを聞かれたときに呼ぶ。
-    """
-    return datetime.now(JST).isoformat(timespec="seconds")
-
+# 「現在時刻」系の独立 tool は持たない — `date` を run_shell 経由で呼べば
+# 十分で、agent コンテナの TZ を Asia/Tokyo に固定してあるので JST が返る
+# (compose.yaml の agent.environment.TZ 参照)。
 
 async def _run_shell_impl(command: str) -> str:
     """run_shell の本体。例外は raise する — `run_shell` 側で catch して
@@ -140,26 +129,32 @@ def _build_run_shell_description() -> str:
     """
     if _SHELL_ALLOWLIST:
         listed = ", ".join(sorted(_SHELL_ALLOWLIST))
-        avail = f"許可されているコマンド名は **{listed}** のみ"
+        avail = f"Only these command names are allowed: **{listed}**"
     else:
-        avail = "現在は何も許可されていない (AGENT_SHELL_ALLOWLIST が空)"
+        avail = (
+            "No commands are currently allowed "
+            "(AGENT_SHELL_ALLOWLIST is empty)"
+        )
     cwd_hint = (
-        f"カレントディレクトリは `{_FILE_ROOT}` (= read_file のルート)。"
-        "相対パスで呼ぶとこの配下を見る (例: `ls`, `cat memo.txt`)。"
-        "他の場所を見たいときは絶対パスを渡す (例: `ls /etc`)。"
+        f"Current working directory is `{_FILE_ROOT}` "
+        "(same as the read_file root). Relative paths target files "
+        "inside that directory (e.g. `ls`, `cat memo.txt`). "
+        "Pass an absolute path to look elsewhere (e.g. `ls /etc`)."
         if _FILE_ROOT
-        else "カレントディレクトリは agent コンテナの `/app`。"
-        "ファイルを指定するときは絶対パスを渡す (例: `ls /etc`)。"
+        else "Current working directory is the agent container's "
+        "`/app`. Pass absolute paths to reach files outside it "
+        "(e.g. `ls /etc`)."
     )
     return (
-        "Linux のシェルコマンドを 1 つ実行して標準出力を返す。\n\n"
-        f"{avail}。これ以外を渡すと [denied] エラーが返る。\n"
-        "パイプ (`|`)、リダイレクト (`>`)、複数コマンドの連結 (`;`, `&&`) は"
-        "構造的に使えない (`shell=True` 不使用)。\n\n"
+        "Run one Linux shell command and return its stdout.\n\n"
+        f"{avail}. Anything else returns a [denied] error.\n"
+        "Pipes (`|`), redirects (`>`), and command chaining "
+        "(`;`, `&&`) are structurally impossible "
+        "(`shell=True` is not used).\n\n"
         f"{cwd_hint}\n\n"
-        "command にはコマンド本体と引数をスペース区切りで渡す "
-        "(例: `\"date\"`, `\"ls\"`)。実行は 5 秒で打ち切られ、"
-        "stdout は 3KB を超えると末尾省略される。"
+        "`command` takes the executable name and its arguments "
+        "separated by spaces (e.g. `\"date\"`, `\"ls\"`). Each call "
+        "is capped at 5 seconds and stdout is truncated past 3KB."
     )
 
 
@@ -235,30 +230,32 @@ async def _web_search_impl(query: str) -> str:
 
 @tool
 async def web_search(query: str) -> str:
-    """インターネットを検索して上位 5 件の概要を返す。
+    """Search the web and return up to 5 result summaries.
 
-    最新ニュース・商品情報・調べごとなど、自分の知識だけでは答えられないことを
-    聞かれたときに呼ぶ。query には自然文の検索クエリを渡す (例:
-    `"今日の東京の天気"`, `"Rust async runtime 比較"`)。
+    Call this for current news, product info, weather, or anything
+    you can't answer from your own knowledge. `query` is a natural-
+    language search string (e.g. `"weather in Tokyo today"`,
+    `"Rust async runtime comparison"`).
 
-    結果は各件 `N. タイトル / snippet / URL` 形式で最大 5 件、全体 1500 字を
-    超えると末尾省略。リアルタイムページ取得や本文全文は別 tool 範囲外なので、
-    snippet を見て要点を自然な言葉で要約して答える。
+    Results come back as `N. title / snippet / URL` per entry, up to
+    5 entries, with the whole payload capped at ~1500 characters.
+    Fetching full page bodies or following links is out of scope —
+    distil the snippets into a short natural-language answer.
     """
     return await _safe_invoke("web_search", _web_search_impl(query))
 
 
 @tool
 async def read_file(path: str) -> str:
-    """指定ファイルを読んで内容をそのまま返す。
+    """Read a file and return its contents verbatim.
 
-    path は `AGENT_FILE_ROOT` (= 共有ディレクトリ) からの相対パスを渡す
-    (例: `"memo.txt"`, `"docs/recipe.md"`)。絶対パスや `..` を含むパスは
-    拒否される。
+    `path` is interpreted relative to `AGENT_FILE_ROOT` (the shared
+    directory), e.g. `"memo.txt"`, `"docs/recipe.md"`. Absolute paths
+    and paths containing `..` are rejected.
 
-    voice agent のユースケース: ユーザに「メモを読んで」「あのファイルを
-    読んで」と言われたとき、ここで内容を取得して読み上げに繋げる。
-    内容は 50 KB を超える場合は末尾が省略される。
+    Use this when the user asks to read a memo or a specific file —
+    fetch the contents here, then summarise or read it back to them.
+    Files larger than 50 KB are truncated at the tail.
     """
     return await _safe_invoke("read_file", _read_file_impl(path))
 
@@ -294,20 +291,17 @@ async def _safe_invoke(name: str, coro) -> str:
 def all_tools() -> list:
     """登録 tool の一覧。`create_react_agent` に渡す。
 
-    issue #19 の段階的な追加に伴い後段の PR で `list_drive_files` /
-    `read_drive_file` が積まれる予定。
+    issue #19 の段階的な追加に伴い後段の PR で別 tool が積まれる可能性あり。
     """
-    return [get_current_datetime, run_shell, read_file, web_search]
+    return [run_shell, read_file, web_search]
 
 
 # tool name → ack phrase。None なら ack 挿入なし。
 #
-# 即応 tool (date / shell / file) は None でよく、遅い tool (web 検索や Drive
-# アクセス) だけ ack を入れて voice agent の無音を埋める。文言は環境変数で
-# 上書き可能にしておくと運用しやすい — Drive 系は対応 tool 追加の PR で同様に
-# AGENT_TOOL_ACK_DRIVE などを追加する想定。
+# 即応 tool (shell / file) は None でよく、遅い tool (web 検索) だけ ack を
+# 入れて voice agent の無音を埋める。文言は環境変数で上書き可能にしておくと
+# 運用しやすい。
 TOOL_ACK_PHRASES: dict[str, str | None] = {
-    "get_current_datetime": None,
     "run_shell": None,
     "read_file": None,
     "web_search": os.environ.get(

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -28,9 +28,11 @@ ack phrase は tool 実行中の無音をカバーする目的の合成 chunk。
 from __future__ import annotations
 
 import asyncio
+import audioop  # Python 3.13 で deprecated だが、stdlib のままで動く間は依存ゼロで便利。
 import json
 import logging
 import os
+import sys
 import time
 import wave
 from pathlib import Path
@@ -61,10 +63,14 @@ _FILE_ROOT: str = os.environ.get("AGENT_FILE_ROOT", "")
 # 即 [error] で返す。
 _AUDIO_IO_SPK_URL: str = os.environ.get("AGENT_AUDIO_IO_SPK_URL", "")
 # audio-io の wire format。WAV のサンプルレート / チャンネル数がこれと
-# 一致しない場合は再生を拒否する (一致しないまま送ると framer が誤解釈
-# して早回し / 遅回しの音が出るため)。defaults はプロジェクト標準。
+# 一致しない場合は audioop で吸収して送り出す (44.1kHz stereo の WAV でも
+# 16kHz mono に変換して再生できる)。defaults はプロジェクト標準。
 _AUDIO_IO_WIRE_RATE: int = int(os.environ.get("AGENT_AUDIO_IO_WIRE_RATE", "16000"))
 _AUDIO_IO_WIRE_CHANNELS: int = int(os.environ.get("AGENT_AUDIO_IO_WIRE_CHANNELS", "1"))
+# サンプルレート / チャンネル不一致は audioop で吸収する (stereo→mono は
+# `tomono`、レート変換は `ratecv`)。LLM が「48kHz の WAV ですが？」と
+# 言い訳せず再生できるようにするための保険。
+_AUDIO_SAMPLE_WIDTH = 2  # s16le 固定 (= 16-bit PCM)
 # 単一再生の壁時計上限 (秒)。1 時間の WAV をうっかり渡されると tool が
 # その間 block するので DoS 対策。
 _AUDIO_PLAY_MAX_S: float = float(os.environ.get("AGENT_AUDIO_PLAY_MAX_S", "300"))
@@ -290,9 +296,11 @@ async def _play_audio_file_impl(path: str) -> str:
     if not p.is_file():
         raise FileNotFoundError(f"not a file: {path}")
 
-    # WAV パースは sync I/O なので thread にオフロード。WAV 形式の検証も
-    # ここで一括 (チャンネル数 / レート / 圧縮 / 長さ / sample width)。
-    def _read_wav() -> tuple[bytes, int, int, int]:
+    # WAV パース + リサンプル / リミックスは sync I/O + CPU 仕事なので
+    # まとめて thread にオフロード。圧縮 / sample width は raise する
+    # (audioop は s16le 固定で扱う)。sample rate / channels の不一致は
+    # ここで吸収して wire format に揃える。
+    def _read_wav() -> tuple[bytes, float, int, int]:
         with wave.open(str(p), "rb") as wav:
             comp = wav.getcomptype()
             if comp != "NONE":
@@ -301,24 +309,13 @@ async def _play_audio_file_impl(path: str) -> str:
                     "give uncompressed PCM (s16le)"
                 )
             sw = wav.getsampwidth()
-            if sw != 2:
+            if sw != _AUDIO_SAMPLE_WIDTH:
                 raise ValueError(
                     f"unsupported sample width {sw * 8} bits; "
                     "only 16-bit PCM (s16le) is supported"
                 )
             fr = wav.getframerate()
             ch = wav.getnchannels()
-            if fr != _AUDIO_IO_WIRE_RATE:
-                raise ValueError(
-                    f"sample rate {fr}Hz does not match audio-io wire "
-                    f"rate {_AUDIO_IO_WIRE_RATE}Hz — re-render the WAV to "
-                    f"{_AUDIO_IO_WIRE_RATE}Hz first"
-                )
-            if ch != _AUDIO_IO_WIRE_CHANNELS:
-                raise ValueError(
-                    f"channels {ch} does not match audio-io wire channels "
-                    f"{_AUDIO_IO_WIRE_CHANNELS}"
-                )
             n = wav.getnframes()
             duration_s = n / fr
             if duration_s > _AUDIO_PLAY_MAX_S:
@@ -326,18 +323,54 @@ async def _play_audio_file_impl(path: str) -> str:
                     f"duration {duration_s:.1f}s exceeds limit "
                     f"{_AUDIO_PLAY_MAX_S:.0f}s"
                 )
-            return wav.readframes(n), n, ch, fr
+            pcm = wav.readframes(n)
 
-    pcm, nframes, nchannels, framerate = await asyncio.to_thread(_read_wav)
-    bytes_per_sample = 2 * nchannels
-    samples_per_frame = framerate * _AUDIO_PLAY_FRAME_MS // 1000
+        # チャンネル変換 (audioop は 1↔2 のみネイティブ対応)。
+        # rate 変換より先にやると後段の処理データ量が減るので少しだけ速い。
+        if ch != _AUDIO_IO_WIRE_CHANNELS:
+            if ch == 2 and _AUDIO_IO_WIRE_CHANNELS == 1:
+                pcm = audioop.tomono(pcm, _AUDIO_SAMPLE_WIDTH, 0.5, 0.5)
+            elif ch == 1 and _AUDIO_IO_WIRE_CHANNELS == 2:
+                pcm = audioop.tostereo(pcm, _AUDIO_SAMPLE_WIDTH, 1.0, 1.0)
+            else:
+                raise ValueError(
+                    f"cannot convert {ch}-channel WAV to "
+                    f"{_AUDIO_IO_WIRE_CHANNELS}-channel wire format "
+                    "(only 1↔2 channel conversions are supported)"
+                )
+
+        # サンプルレート変換。`state=None` は新規変換 (連続呼び出し時の
+        # 補間状態を引き継がない) を意味する。今回は単発なので None で OK。
+        if fr != _AUDIO_IO_WIRE_RATE:
+            pcm, _ = audioop.ratecv(
+                pcm,
+                _AUDIO_SAMPLE_WIDTH,
+                _AUDIO_IO_WIRE_CHANNELS,
+                fr,
+                _AUDIO_IO_WIRE_RATE,
+                None,
+            )
+
+        return pcm, duration_s, fr, ch
+
+    pcm, duration_s, src_rate, src_ch = await asyncio.to_thread(_read_wav)
+    bytes_per_sample = _AUDIO_SAMPLE_WIDTH * _AUDIO_IO_WIRE_CHANNELS
+    samples_per_frame = _AUDIO_IO_WIRE_RATE * _AUDIO_PLAY_FRAME_MS // 1000
     bytes_per_frame = samples_per_frame * bytes_per_sample
-    duration_s = nframes / framerate
 
-    log.info(
-        "play_audio_file: %s (%.1fs, %dHz, %dch) → %s",
-        p.name, duration_s, framerate, nchannels, _AUDIO_IO_SPK_URL,
-    )
+    if (src_rate, src_ch) != (_AUDIO_IO_WIRE_RATE, _AUDIO_IO_WIRE_CHANNELS):
+        log.info(
+            "play_audio_file: %s (%.1fs) converted %dHz/%dch → %dHz/%dch → %s",
+            p.name, duration_s, src_rate, src_ch,
+            _AUDIO_IO_WIRE_RATE, _AUDIO_IO_WIRE_CHANNELS,
+            _AUDIO_IO_SPK_URL,
+        )
+    else:
+        log.info(
+            "play_audio_file: %s (%.1fs, %dHz, %dch) → %s",
+            p.name, duration_s, _AUDIO_IO_WIRE_RATE,
+            _AUDIO_IO_WIRE_CHANNELS, _AUDIO_IO_SPK_URL,
+        )
 
     # ws_connect の sock_connect で接続フェーズを短く (audio-io が居なければ
     # ここで即落ちて [error] にする)。全体 timeout は意図的に None — 長尺
@@ -399,10 +432,12 @@ def _build_play_audio_description() -> str:
     return (
         "Play a WAV audio file via the speaker.\n\n"
         "`path` is an **absolute** filesystem path to a WAV file. The file "
-        f"must be uncompressed 16-bit PCM (s16le) at "
-        f"{_AUDIO_IO_WIRE_RATE}Hz with {_AUDIO_IO_WIRE_CHANNELS} channel(s) "
-        "(audio-io's wire format). Relative paths, compressed WAVs, and "
-        "mismatched sample rate / channels are rejected.\n\n"
+        "must be uncompressed 16-bit PCM (s16le). Sample rate and channel "
+        "count are auto-converted to "
+        f"{_AUDIO_IO_WIRE_RATE}Hz / {_AUDIO_IO_WIRE_CHANNELS} channel(s) "
+        "(audio-io's wire format) if they differ, so 44.1kHz stereo and "
+        "48kHz mono and similar are all accepted. Relative paths, "
+        "compressed WAVs, and >2-channel surround formats are rejected.\n\n"
         "Call this when the user asks to play a specific audio file — "
         "for example a pre-rendered news summary or notification produced "
         "by another agent. The tool blocks until playback completes; if "
@@ -489,3 +524,96 @@ TOOL_ACK_PHRASES: dict[str, str | None] = {
         else None
     ),
 }
+
+
+# --- CLI (`python tools.py <tool> <args>`) -------------------------------
+#
+# LLM 抜きで個別 tool を手叩きするための薄い entry point。
+# LangGraph ToolNode は `.ainvoke({"path": "..."})` を呼ぶだけなので、
+# ここでも同じ呼び出しを再現する。これで「LLM が呼ぶときと同じコードパス」
+# (= `_safe_invoke` で例外を string 化、ack は CLI には出ない) で挙動確認できる。
+#
+# Usage:
+#   python tools.py                                 # list tools
+#   python tools.py <name>                          # show args & description
+#   python tools.py <name> <value>                  # single-arg tools
+#   python tools.py <name> key=value [key=value]    # multi-arg / named
+#
+# 例:
+#   python tools.py play_audio_file /workspace/share/foo.wav
+#   python tools.py run_shell command="ls -la"
+def _cli_list(tools: list) -> None:
+    print("available tools:")
+    for t in tools:
+        desc = (t.description or "").splitlines()[0] if t.description else ""
+        print(f"  {t.name:20s} {desc}")
+
+
+def _cli_show(t) -> None:
+    print(f"{t.name}\n")
+    print(t.description or "(no description)")
+    print()
+    print("args:")
+    for k, v in (t.args or {}).items():
+        print(f"  {k}: {v}")
+
+
+def _cli_parse(values: list[str], schema_keys: list[str]) -> dict:
+    """argv 後半を {param: value} に直す。
+
+    - 全要素に `=` を含むなら全部 key=value 形式とみなす
+    - そうでなければ positional 扱いで schema 順に zip
+    - 引数 1 個 + schema 1 個 の最頻ケースは positional でそのまま渡る
+    """
+    if not values:
+        return {}
+    if all("=" in v for v in values):
+        out: dict = {}
+        for v in values:
+            k, _, val = v.partition("=")
+            out[k] = val
+        return out
+    if len(values) != len(schema_keys):
+        raise SystemExit(
+            f"expected {len(schema_keys)} positional arg(s) "
+            f"({', '.join(schema_keys) or '-'}), got {len(values)}; "
+            "use key=value form for multi-arg tools"
+        )
+    return dict(zip(schema_keys, values))
+
+
+async def _cli_main(argv: list[str]) -> int:
+    tools = all_tools()
+    by_name = {t.name: t for t in tools}
+
+    if not argv or argv[0] in ("-h", "--help"):
+        print("usage: python tools.py <tool_name> [<args...>]\n")
+        _cli_list(tools)
+        return 0
+
+    name = argv[0]
+    if name not in by_name:
+        print(f"unknown tool: {name}", file=sys.stderr)
+        print(f"available: {', '.join(by_name)}", file=sys.stderr)
+        return 1
+
+    tool_obj = by_name[name]
+    if len(argv) == 1:
+        _cli_show(tool_obj)
+        return 0
+
+    args = _cli_parse(argv[1:], list((tool_obj.args or {}).keys()))
+    result = await tool_obj.ainvoke(args)
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    # CLI 専用に logging を stderr へ INFO で出す。production の app.py は
+    # 自前で logging 設定するので、こちらの basicConfig は __main__ 経路だけ。
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+    sys.exit(asyncio.run(_cli_main(sys.argv[1:])))

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -37,6 +37,7 @@ import sys
 import time
 import wave
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
 from langchain_core.tools import tool
@@ -75,6 +76,31 @@ _AUDIO_SAMPLE_WIDTH = 2  # s16le 固定 (= 16-bit PCM)
 # 単一再生の壁時計上限 (秒)。1 時間の WAV をうっかり渡されると tool が
 # その間 block するので DoS 対策。
 _AUDIO_PLAY_MAX_S: float = float(os.environ.get("AGENT_AUDIO_PLAY_MAX_S", "300"))
+
+
+def _derive_stop_url(spk_url: str) -> str:
+    """play 用の /spk WS URL から、停止用の /spk/stop HTTP URL を導出する。
+
+    `ws://host:7010/spk?track=1` → `http://host:7010/spk/stop?track=1`。
+    scheme は ws→http / wss→https、path 末尾の `/spk` に `/stop` を足し、
+    `?track=N` クエリはそのまま引き継ぐ (= play と同じ track を狙い撃ちする)。
+    設定を 1 本化するため専用 env は持たず、ここで変換する。
+    """
+    if not spk_url:
+        return ""
+    parts = urlsplit(spk_url)
+    scheme = {"ws": "http", "wss": "https"}.get(parts.scheme, parts.scheme)
+    path = parts.path.rstrip("/")
+    # 通常 path は `/spk`。それ以外でも `/stop` を足して壊さないようにする。
+    path = (path[: -len("/spk")] + "/spk/stop") if path.endswith("/spk") else path + "/stop"
+    return urlunsplit((scheme, parts.netloc, path, parts.query, parts.fragment))
+
+
+# stop_audio: play_audio_file が使う track を flush する HTTP エンドポイント。
+# 空なら tool は「使用不可」を LLM に伝え、呼ばれても即 [error]。
+_AUDIO_IO_STOP_URL: str = _derive_stop_url(_AUDIO_IO_SPK_URL)
+# /spk/stop は即応 (flush signal を投げるだけ) なので短め。
+_AUDIO_STOP_TIMEOUT_S = 5.0
 
 # 出力サイズ上限 (issue #19 設計の「個別 tool ごと truncate」決定に基づく)。
 _SHELL_STDOUT_MAX = 3000
@@ -527,6 +553,62 @@ async def play_audio_file(paths: list[str]) -> str:
     return await _safe_invoke("play_audio_file", _play_audio_file_impl(paths))
 
 
+async def _stop_audio_impl() -> str:
+    """stop_audio 本体。audio-io の /spk/stop?track=N を POST して、
+    play_audio_file が使う track のリングを flush する。
+
+    flush は「今鳴っている / バッファに残っている PCM を捨てる」操作なので、
+    何も鳴っていなくても 200 が返る no-op。LLM の声 (TTS) は別 track なので
+    影響しない。即応操作なので drain handshake は不要。
+    """
+    if not _AUDIO_IO_STOP_URL:
+        raise RuntimeError(
+            "AGENT_AUDIO_IO_SPK_URL is not set — audio stop is disabled"
+        )
+    timeout = aiohttp.ClientTimeout(total=_AUDIO_STOP_TIMEOUT_S)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(_AUDIO_IO_STOP_URL) as resp:
+            body = await resp.text()
+            if resp.status != 200:
+                # 404 = track 範囲外 (audio-io が当該 track を持っていない)
+                # など。retry しても通らないが [error] で LLM に状況を渡す。
+                raise RuntimeError(
+                    f"audio-io /spk/stop returned {resp.status}: {body[:200]}"
+                )
+    log.info("stop_audio: flushed via %s", _AUDIO_IO_STOP_URL)
+    return "stopped audio playback"
+
+
+def _build_stop_audio_description() -> str:
+    """stop_audio の description を起動時 env に応じて動的生成する。"""
+    if not _AUDIO_IO_STOP_URL:
+        return (
+            "Stop audio file playback on the speaker.\n\n"
+            "**CURRENTLY UNAVAILABLE** — the AGENT_AUDIO_IO_SPK_URL env "
+            "is not set, so audio playback (and thus stopping it) is "
+            "disabled in this environment. Do NOT call this tool; tell the "
+            "user in one sentence that audio is not configured here."
+        )
+    return (
+        "Stop audio file playback immediately.\n\n"
+        "Flushes the audio-io playback track that play_audio_file uses, "
+        "cutting off whatever WAV is currently playing on the speaker. "
+        "Your own spoken replies (text-to-speech) play on a different "
+        "track and are NOT affected by this. Takes no arguments. Safe to "
+        "call even when nothing is playing — it is a harmless no-op in "
+        "that case.\n\n"
+        "Call this when the user asks to stop or silence the audio that is "
+        "playing — for example 「音声止めて」「再生やめて」「stop the audio」."
+    )
+
+
+@tool(description=_build_stop_audio_description())
+async def stop_audio() -> str:
+    # description は @tool(description=...) で動的注入。詳細は
+    # `_build_stop_audio_description` の docstring を参照。
+    return await _safe_invoke("stop_audio", _stop_audio_impl())
+
+
 @tool
 async def read_file(path: str) -> str:
     """Read a file and return its contents verbatim.
@@ -575,7 +657,7 @@ def all_tools() -> list:
 
     issue #19 の段階的な追加に伴い後段の PR で別 tool が積まれる可能性あり。
     """
-    return [run_shell, read_file, web_search, play_audio_file]
+    return [run_shell, read_file, web_search, play_audio_file, stop_audio]
 
 
 # tool name → ack phrase。None なら ack 挿入なし。
@@ -597,6 +679,8 @@ TOOL_ACK_PHRASES: dict[str, str | None] = {
         if _AUDIO_IO_SPK_URL
         else None
     ),
+    # stop は即応 (flush signal を投げるだけ) なので ack 不要。
+    "stop_audio": None,
 }
 
 
@@ -616,6 +700,7 @@ TOOL_ACK_PHRASES: dict[str, str | None] = {
 # 例:
 #   python tools.py play_audio_file /workspace/share/foo.wav
 #   python tools.py play_audio_file share/a.wav share/b.wav   # 連続再生
+#   python tools.py stop_audio                                 # 再生停止
 #   python tools.py run_shell command="ls -la"
 def _cli_list(tools: list) -> None:
     print("available tools:")
@@ -674,6 +759,11 @@ async def _cli_main(argv: list[str]) -> int:
 
     tool_obj = by_name[name]
     if len(argv) == 1:
+        # 引数なしの tool (e.g. stop_audio) は名前だけで実行する。
+        # スキーマに引数があるものは従来通り description を表示。
+        if not (tool_obj.args or {}):
+            print(await tool_obj.ainvoke({}))
+            return 0
         _cli_show(tool_obj)
         return 0
 

--- a/audio-io/config.example.toml
+++ b/audio-io/config.example.toml
@@ -32,3 +32,10 @@ playback_buffer_ms = 10000
 # receives a single Lagged warning covering the skipped frames. Increase for
 # bursty consumers, decrease for tighter latency.
 mic_broadcast_frames = 64
+# Number of independent playback tracks. Each track owns its own cpal output
+# stream + ring buffer; WASAPI shared mode mixes them at the OS layer so
+# multiple clients can play in parallel without per-sample interference.
+# Track id is selected with `?track=N` on the /spk WebSocket (default 0 keeps
+# the legacy single-client setup working unchanged); `/spk/stop` accepts the
+# same `?track=N` to stop just that track, or no query to stop all.
+playback_tracks = 2

--- a/audio-io/src/config.rs
+++ b/audio-io/src/config.rs
@@ -39,6 +39,15 @@ pub struct RuntimeConfig {
     pub autostart: bool,
     pub playback_buffer_ms: u32,
     pub mic_broadcast_frames: u32,
+    /// Number of parallel playback tracks. Each track owns its own cpal
+    /// output stream, ring buffer, producer task, and `FlushSignals`,
+    /// and is identified externally by integer id `0..playback_tracks`.
+    /// WASAPI shared mode (the Windows default) mixes the per-stream
+    /// outputs at the OS layer, so independent senders never interfere.
+    /// `/spk` (no query) defaults to track 0 for backwards compatibility
+    /// with the existing TTS-streamer client; new callers (e.g. an agent
+    /// playing pre-rendered audio files) pass `?track=1`.
+    pub playback_tracks: u32,
 }
 
 impl Default for Config {
@@ -86,6 +95,7 @@ impl Default for RuntimeConfig {
             autostart: true,
             playback_buffer_ms: 200,
             mic_broadcast_frames: 64,
+            playback_tracks: 2,
         }
     }
 }
@@ -123,6 +133,9 @@ impl Config {
         }
         if self.runtime.mic_broadcast_frames == 0 {
             anyhow::bail!("runtime.mic_broadcast_frames must be >= 1");
+        }
+        if self.runtime.playback_tracks == 0 {
+            anyhow::bail!("runtime.playback_tracks must be >= 1");
         }
         Ok(())
     }

--- a/audio-io/src/http.rs
+++ b/audio-io/src/http.rs
@@ -1,10 +1,12 @@
-use axum::extract::State;
+use std::collections::HashMap;
+
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use cpal::traits::{DeviceTrait, HostTrait};
 use serde::Serialize;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::service;
 use crate::state::AppState;
@@ -96,8 +98,60 @@ pub async fn stop(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
-pub async fn spk_stop(State(state): State<AppState>) -> impl IntoResponse {
-    state.flush.trigger();
-    info!("spk_stop: flush signaled");
-    Json(serde_json::json!({ "status": "flushed" }))
+pub async fn spk_stop(
+    Query(params): Query<HashMap<String, String>>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    // `?track=N` stops just that track; absent = stop all tracks
+    // (treated as a full audio reset — useful as a global barge-in that
+    // takes out any TTS-streamer and any agent-side file playback in
+    // one shot).
+    let requested: Option<usize> = params.get("track").and_then(|s| s.parse().ok());
+    let tracks = state.spk_tracks.lock().await;
+    match requested {
+        Some(idx) => match tracks.get(idx) {
+            Some(t) => {
+                t.flush.trigger();
+                info!(track = idx, "spk_stop: flush signaled");
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({ "status": "flushed", "track": idx })),
+                )
+                    .into_response()
+            }
+            None => {
+                warn!(
+                    track = idx,
+                    n_tracks = tracks.len(),
+                    "spk_stop: track out of range"
+                );
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({
+                        "status": "no such track",
+                        "track": idx,
+                        "n_tracks": tracks.len(),
+                    })),
+                )
+                    .into_response()
+            }
+        },
+        None => {
+            for t in tracks.iter() {
+                t.flush.trigger();
+            }
+            info!(
+                n_tracks = tracks.len(),
+                "spk_stop: flush signaled (all tracks)"
+            );
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "status": "flushed",
+                    "n_tracks": tracks.len(),
+                })),
+            )
+                .into_response()
+        }
+    }
 }

--- a/audio-io/src/lib.rs
+++ b/audio-io/src/lib.rs
@@ -18,7 +18,7 @@ use tokio::sync::{broadcast, Mutex};
 use tracing::info;
 
 use crate::config::Config;
-use crate::state::{AppState, FlushSignals, ServiceHandles};
+use crate::state::{AppState, ServiceHandles};
 
 pub async fn run(config: Config) -> Result<()> {
     config.validate().context("invalid config")?;
@@ -48,8 +48,7 @@ pub fn build_state(config: Config) -> AppState {
     AppState {
         config: Arc::new(config),
         mic_tx,
-        spk_tx: Arc::new(Mutex::new(None)),
-        flush: Arc::new(FlushSignals::new()),
+        spk_tracks: Arc::new(Mutex::new(Vec::new())),
         handles: Arc::new(Mutex::new(ServiceHandles::default())),
     }
 }

--- a/audio-io/src/playback.rs
+++ b/audio-io/src/playback.rs
@@ -135,6 +135,7 @@ struct PlaybackReady {
 }
 
 pub fn start_playback(
+    track_id: usize,
     device_name: &str,
     audio: AudioConfig,
     buffer_ms: u32,
@@ -148,10 +149,11 @@ pub fn start_playback(
     let stats_cb = stats.clone();
 
     let thread = std::thread::Builder::new()
-        .name("audio-playback".into())
+        .name(format!("audio-playback-{track_id}"))
         .spawn(move || {
             let ready_tx_clone = ready_tx.clone();
             if let Err(e) = run_playback(
+                track_id,
                 &device_name,
                 buffer_ms,
                 flush_cb,
@@ -159,7 +161,7 @@ pub fn start_playback(
                 ready_tx,
                 shutdown_rx,
             ) {
-                error!("playback thread error: {e:?}");
+                error!(track_id, "playback thread error: {e:?}");
                 let _ = ready_tx_clone.send(Err(e));
             }
         })?;
@@ -264,6 +266,7 @@ fn find_output_device(name: &str) -> Result<cpal::Device> {
 }
 
 fn run_playback(
+    track_id: usize,
     device_name: &str,
     buffer_ms: u32,
     flush: Arc<FlushSignals>,
@@ -281,6 +284,7 @@ fn run_playback(
     let stream_config: StreamConfig = default_config.into();
 
     info!(
+        track_id,
         device = ?device.name().ok(),
         native_rate,
         native_channels,

--- a/audio-io/src/service.rs
+++ b/audio-io/src/service.rs
@@ -1,19 +1,21 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Context, Result};
 use tracing::info;
 
 use crate::capture::start_capture;
 use crate::playback::start_playback;
-use crate::state::{AppState, ServiceHandles};
+use crate::state::{AppState, FlushSignals, PlaybackTrack, ServiceHandles};
 
 pub async fn start_services(state: &AppState) -> Result<()> {
     let mut handles = state
         .handles
         .try_lock()
         .map_err(|_| anyhow!("start/stop already in progress"))?;
-    if handles.capture.is_some() || handles.playback.is_some() {
+    if handles.capture.is_some() || !handles.playback.is_empty() {
         info!("start_services: restarting existing services");
         drop_inner(&mut handles);
-        *state.spk_tx.lock().await = None;
+        state.spk_tracks.lock().await.clear();
     }
 
     let capture = start_capture(
@@ -24,17 +26,33 @@ pub async fn start_services(state: &AppState) -> Result<()> {
     .context("start_capture")?;
     handles.capture = Some(capture);
 
-    let playback = start_playback(
-        &state.config.output.device,
-        state.config.audio.clone(),
-        state.config.runtime.playback_buffer_ms,
-        state.flush.clone(),
-    )
-    .context("start_playback")?;
-    *state.spk_tx.lock().await = Some(playback.sender());
-    handles.playback = Some(playback);
+    // Open `playback_tracks` independent cpal output streams against the
+    // same device. WASAPI shared mode mixes them at the OS layer, so
+    // callers (TTS-streamer on track 0, agent on track 1, ...) can push
+    // PCM in parallel without per-sample stomping or contention.
+    let n_tracks = state.config.runtime.playback_tracks as usize;
+    let mut new_tracks = Vec::with_capacity(n_tracks);
+    let mut new_handles = Vec::with_capacity(n_tracks);
+    for track_id in 0..n_tracks {
+        let flush = Arc::new(FlushSignals::new());
+        let playback = start_playback(
+            track_id,
+            &state.config.output.device,
+            state.config.audio.clone(),
+            state.config.runtime.playback_buffer_ms,
+            flush.clone(),
+        )
+        .with_context(|| format!("start_playback (track {track_id})"))?;
+        new_tracks.push(PlaybackTrack {
+            sender: playback.sender(),
+            flush,
+        });
+        new_handles.push(playback);
+    }
+    *state.spk_tracks.lock().await = new_tracks;
+    handles.playback = new_handles;
 
-    info!("services started");
+    info!(n_tracks, "services started");
     Ok(())
 }
 
@@ -44,12 +62,15 @@ pub async fn stop_services(state: &AppState) -> Result<()> {
         .try_lock()
         .map_err(|_| anyhow!("start/stop already in progress"))?;
     drop_inner(&mut handles);
-    *state.spk_tx.lock().await = None;
+    state.spk_tracks.lock().await.clear();
     info!("services stopped");
     Ok(())
 }
 
 fn drop_inner(handles: &mut ServiceHandles) {
     handles.capture = None;
-    handles.playback = None;
+    // Drop in reverse order so a track's logger task doesn't see the
+    // producer task abort mid-Tick (purely defensive — Drop on each is
+    // independent — but keeps log order tidy).
+    handles.playback.clear();
 }

--- a/audio-io/src/state.rs
+++ b/audio-io/src/state.rs
@@ -18,9 +18,23 @@ pub struct AppState {
     /// can ignore the first field; the WS handler exposes it on the wire
     /// only when the client requests it via `?ts=1`.
     pub mic_tx: broadcast::Sender<(u64, Bytes)>,
-    pub spk_tx: Arc<Mutex<Option<mpsc::Sender<PlaybackMessage>>>>,
-    pub flush: Arc<FlushSignals>,
+    /// Per-playback-track endpoints. Vec index = track id (= `?track=N`
+    /// on the /spk WS). Empty Vec while services are stopped; populated
+    /// at `service::start_services` with `config.runtime.playback_tracks`
+    /// entries, each pointing at an independent cpal output stream that
+    /// the Windows audio engine mixes at the OS layer.
+    pub spk_tracks: Arc<Mutex<Vec<PlaybackTrack>>>,
     pub handles: Arc<Mutex<ServiceHandles>>,
+}
+
+/// One playback track's user-facing handles. The producer task and cpal
+/// thread own clones of these (the sender via the channel, the flush
+/// signal via `Arc::clone`), and so do the `/spk` / `/spk/stop` HTTP
+/// handlers — `spk_tracks` lets them route by track id.
+#[derive(Clone)]
+pub struct PlaybackTrack {
+    pub sender: mpsc::Sender<PlaybackMessage>,
+    pub flush: Arc<FlushSignals>,
 }
 
 pub struct FlushSignals {
@@ -51,5 +65,7 @@ impl Default for FlushSignals {
 #[derive(Default)]
 pub struct ServiceHandles {
     pub capture: Option<CaptureHandle>,
-    pub playback: Option<PlaybackHandle>,
+    /// Vec index = track id. Populated in lockstep with
+    /// `AppState.spk_tracks`; both are emptied on `stop_services`.
+    pub playback: Vec<PlaybackHandle>,
 }

--- a/audio-io/src/ws.rs
+++ b/audio-io/src/ws.rs
@@ -64,12 +64,22 @@ async fn handle_mic(mut socket: WebSocket, state: AppState, with_ts: bool) {
     info!("mic ws: client disconnected");
 }
 
-pub async fn ws_spk(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_spk(socket, state))
+pub async fn ws_spk(
+    ws: WebSocketUpgrade,
+    Query(params): Query<HashMap<String, String>>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    // `?track=N` picks one of the parallel playback streams (default 0).
+    // 0 keeps the existing TTS-streamer client working unmodified.
+    let track_id: usize = params
+        .get("track")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    ws.on_upgrade(move |socket| handle_spk(socket, state, track_id))
 }
 
-async fn handle_spk(mut socket: WebSocket, state: AppState) {
-    info!("spk ws: client connected");
+async fn handle_spk(mut socket: WebSocket, state: AppState, track_id: usize) {
+    info!(track_id, "spk ws: client connected");
     // Tracks whether this WS actually pushed any PCM. cpal is always
     // running (consuming silence when no producer), so a drift report
     // for a zero-PCM session would still log a number — but it would
@@ -78,15 +88,19 @@ async fn handle_spk(mut socket: WebSocket, state: AppState) {
     // line is unambiguously "this session's PCM throughput vs hw clock".
     let mut pcm_frames_received: u64 = 0;
     let spk_tx = {
-        let guard = state.spk_tx.lock().await;
-        match guard.as_ref() {
-            Some(tx) => tx.clone(),
+        let guard = state.spk_tracks.lock().await;
+        match guard.get(track_id) {
+            Some(t) => t.sender.clone(),
             None => {
-                warn!("spk ws: playback not running; closing");
+                warn!(
+                    track_id,
+                    n_tracks = guard.len(),
+                    "spk ws: track id out of range or playback not running; closing"
+                );
                 let _ = socket
                     .send(Message::Close(Some(CloseFrame {
                         code: close_code::POLICY,
-                        reason: Cow::Borrowed("playback not running"),
+                        reason: Cow::Borrowed("invalid track or playback not running"),
                     })))
                     .await;
                 return;
@@ -97,11 +111,11 @@ async fn handle_spk(mut socket: WebSocket, state: AppState) {
     // Hardware-vs-system clock drift snapshot. We baseline cpal's
     // hardware-clock-paced counters at connect and diff at disconnect;
     // the wall-clock duration of the session is the system-clock
-    // reference. Output device may not be running (rare), in which case
-    // we simply skip the drift report.
+    // reference. The drift is per-track (each cpal stream has its own
+    // hardware-clock-paced sample counter).
     let drift_baseline = {
         let guard = state.handles.lock().await;
-        guard.playback.as_ref().map(|h| {
+        guard.playback.get(track_id).map(|h| {
             let (cb, samples) = h.stats().snapshot();
             (
                 Instant::now(),
@@ -217,6 +231,7 @@ async fn handle_spk(mut socket: WebSocket, state: AppState) {
             };
             let drift_ms = consumed_ms as i64 - elapsed_ms as i64;
             info!(
+                track_id,
                 elapsed_ms,
                 callbacks,
                 consumed_samples = consumed,
@@ -227,5 +242,5 @@ async fn handle_spk(mut socket: WebSocket, state: AppState) {
             );
         }
     }
-    info!("spk ws: client disconnected");
+    info!(track_id, "spk ws: client disconnected");
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -391,6 +391,24 @@ services:
       # below. Prevents an infinite retry loop on a tool that always
       # fails. Ignored when AGENT_TOOLS_ENABLED=false.
       AGENT_TOOL_RECURSION_LIMIT: "${AGENT_TOOL_RECURSION_LIMIT:-6}"
+      # run_shell tool — CSV of allowed command *names* (argv[0] match,
+      # no prefix/regex). Empty list = run_shell is effectively disabled
+      # (every command rejected). `shell=True` is never used, so pipes
+      # / redirects / `&&` are structurally impossible regardless of
+      # this allowlist. Default: read-only diagnostics only — no rm /
+      # curl / sh / shell / bash / sudo / etc.
+      AGENT_SHELL_ALLOWLIST: "${AGENT_SHELL_ALLOWLIST:-date,uptime,uname,df,ip,who}"
+      # read_file tool — absolute path *inside the container* that the
+      # agent may read from. Files outside this root (including via
+      # `..` or symlinks) are rejected by the sandbox. Empty = read_file
+      # is effectively disabled (every call rejects with "not
+      # configured"). To actually expose host files: set this env to
+      # the container path you'll mount, AND add a bind-mount line to
+      # `volumes:` below, e.g.
+      #     - /home/me/voice-share:/workspace/share:ro
+      # The `:ro` suffix is recommended — read_file never writes, and
+      # ro guards against any future tool that might.
+      AGENT_FILE_ROOT: "${AGENT_FILE_ROOT:-}"
     volumes:
       - agent-data:/data
     # No `ports:` publish — agent is reached by orchestrator via the

--- a/compose.yaml
+++ b/compose.yaml
@@ -396,6 +396,15 @@ services:
       # below. Prevents an infinite retry loop on a tool that always
       # fails. Ignored when AGENT_TOOLS_ENABLED=false.
       AGENT_TOOL_RECURSION_LIMIT: "${AGENT_TOOL_RECURSION_LIMIT:-6}"
+      # Tool-use behavior policy — *separate* from AGENT_SYSTEM_PROMPT
+      # (which is persona / speaking style). Appended after the persona
+      # only when AGENT_TOOLS_ENABLED=true. Controls how the LLM
+      # decides to call tools, retries on failure, plans multi-step
+      # work, and avoids bouncing answerable questions back to the
+      # user. Empty (default) means the agent uses the long built-in
+      # policy in agent/app.py — override in .env only if you need
+      # different guidance (e.g. domain-specific tool etiquette).
+      AGENT_TOOL_SYSTEM_SUFFIX: "${AGENT_TOOL_SYSTEM_SUFFIX:-}"
       # run_shell tool — CSV of allowed command *names* (argv[0] match,
       # no prefix/regex). Empty list = run_shell is effectively disabled
       # (every command rejected). `shell=True` is never used, so pipes

--- a/compose.yaml
+++ b/compose.yaml
@@ -396,9 +396,11 @@ services:
       # no prefix/regex). Empty list = run_shell is effectively disabled
       # (every command rejected). `shell=True` is never used, so pipes
       # / redirects / `&&` are structurally impossible regardless of
-      # this allowlist. Default: read-only diagnostics only — no rm /
-      # curl / sh / shell / bash / sudo / etc.
-      AGENT_SHELL_ALLOWLIST: "${AGENT_SHELL_ALLOWLIST:-date,uptime,uname,df,ip,who}"
+      # this allowlist. The allowlist value is injected into the
+      # tool's description at agent startup so the LLM sees the actual
+      # set it's allowed to call (override the env → restart agent →
+      # LLM sees the new list).
+      AGENT_SHELL_ALLOWLIST: "${AGENT_SHELL_ALLOWLIST:-date,ls,cat}"
       # read_file tool — absolute path *inside the container* that the
       # agent may read from. Files outside this root (including via
       # `..` or symlinks) are rejected by the sandbox. Empty = read_file

--- a/compose.yaml
+++ b/compose.yaml
@@ -458,6 +458,14 @@ services:
       # Host share dir → /workspace/share (read-only). The host path is
       # taken from AGENT_SHARE_DIR (see env block above for docs).
       - "${AGENT_SHARE_DIR:-./share}:/workspace/share:ro"
+    extra_hosts:
+      # play_audio_file tool reaches audio-io on the host via
+      # AGENT_AUDIO_IO_SPK_URL (default `ws://host.docker.internal:...`).
+      # On plain Linux docker (incl. WSL2) `host.docker.internal` is not
+      # resolved by default; host-gateway maps it to the bridge network's
+      # gateway, which is where audio-io.exe is reachable. Matches the
+      # same line on tts-streamer / vad / wake-word.
+      - "host.docker.internal:host-gateway"
     # No `ports:` publish — agent is reached by orchestrator via the
     # compose network (http://agent:7080). Keeping the port internal
     # means the unauthenticated /api/chat surface isn't exposed on the

--- a/compose.yaml
+++ b/compose.yaml
@@ -367,6 +367,10 @@ services:
     container_name: kklocalagent-agent
     restart: unless-stopped
     environment:
+      # Container timezone. `run_shell` の `date` がそのまま voice agent の
+      # 「現在時刻」用 tool として機能するようにここで JST に固定する。
+      # python:slim はデフォルト UTC なので、立てたままだと date が UTC を返す。
+      TZ: "${TZ:-Asia/Tokyo}"
       AGENT_OLLAMA_URL: http://llm:11434
       AGENT_MODEL: *llm-model
       # Voice-assistant persona — prepended at invoke time on every

--- a/compose.yaml
+++ b/compose.yaml
@@ -424,6 +424,27 @@ services:
       # the ack (rare — the search is slow enough that the silence is
       # noticeable). The default is tuned for voice (タメ口, short).
       AGENT_TOOL_ACK_WEB_SEARCH: "${AGENT_TOOL_ACK_WEB_SEARCH:-ちょっと検索してみるね。}"
+      # play_audio_file tool — WebSocket URL of audio-io's /spk endpoint
+      # with `?track=N` so the agent's playback uses a parallel cpal
+      # stream and never stomps on tts-streamer's TTS stream. audio-io
+      # must be running on the Windows host with
+      # `runtime.playback_tracks >= 2`. Set empty in `.env` to disable
+      # the tool entirely — the tool description then tells the LLM the
+      # feature is unavailable so it can answer the user gracefully
+      # instead of trying and failing.
+      AGENT_AUDIO_IO_SPK_URL: "${AGENT_AUDIO_IO_SPK_URL:-ws://${WINDOWS_HOST:-host.docker.internal}:7010/spk?track=1}"
+      # Wire format audio-io expects on /spk. The PCM in the WAV file
+      # must match these — re-render the WAV if your audio-io is
+      # configured differently. Defaults match the project's standard
+      # audio-io setup (16 kHz mono 16-bit PCM s16le).
+      AGENT_AUDIO_IO_WIRE_RATE: "${AGENT_AUDIO_IO_WIRE_RATE:-16000}"
+      AGENT_AUDIO_IO_WIRE_CHANNELS: "${AGENT_AUDIO_IO_WIRE_CHANNELS:-1}"
+      # Hard cap on play_audio_file duration (seconds). Defensive against
+      # a long file blocking the agent for minutes. 300 s = 5 min covers
+      # typical news / weather briefings.
+      AGENT_AUDIO_PLAY_MAX_S: "${AGENT_AUDIO_PLAY_MAX_S:-300}"
+      # Filler ack spoken just before playback begins. Empty disables.
+      AGENT_TOOL_ACK_PLAY_AUDIO: "${AGENT_TOOL_ACK_PLAY_AUDIO:-音声を再生するね。}"
     volumes:
       - agent-data:/data
     # No `ports:` publish — agent is reached by orchestrator via the

--- a/compose.yaml
+++ b/compose.yaml
@@ -380,6 +380,17 @@ services:
       # assumes one operator per process, so going idle = "the
       # operator walked away" → next turn is a fresh conversation.
       AGENT_SESSION_IDLE_SEC: "${AGENT_SESSION_IDLE_SEC:-600}"
+      # Feature flag for tool-calling (issue #19). Default off so this
+      # is a strict no-op until you opt in. When on, the chat graph
+      # becomes a ReAct agent (LLM ↔ tool loop) with the tools defined
+      # in agent/tools.py; when off, the legacy single-node chat graph
+      # is used (bit-for-bit identical to pre-#19 behaviour).
+      AGENT_TOOLS_ENABLED: "${AGENT_TOOLS_ENABLED:-false}"
+      # Caps the agent_node → tools → agent_node loop per turn. 6 ≈ up
+      # to 3 chained tool calls before we surface the fallback line
+      # below. Prevents an infinite retry loop on a tool that always
+      # fails. Ignored when AGENT_TOOLS_ENABLED=false.
+      AGENT_TOOL_RECURSION_LIMIT: "${AGENT_TOOL_RECURSION_LIMIT:-6}"
     volumes:
       - agent-data:/data
     # No `ports:` publish — agent is reached by orchestrator via the

--- a/compose.yaml
+++ b/compose.yaml
@@ -409,6 +409,12 @@ services:
       # The `:ro` suffix is recommended — read_file never writes, and
       # ro guards against any future tool that might.
       AGENT_FILE_ROOT: "${AGENT_FILE_ROOT:-}"
+      # web_search tool — filler ack phrase the agent emits before the
+      # actual DuckDuckGo round-trip, so the voice agent doesn't go
+      # silent for the ~1-2 s search latency. Set empty to disable
+      # the ack (rare — the search is slow enough that the silence is
+      # noticeable). The default is tuned for voice (タメ口, short).
+      AGENT_TOOL_ACK_WEB_SEARCH: "${AGENT_TOOL_ACK_WEB_SEARCH:-ちょっと検索してみるね。}"
     volumes:
       - agent-data:/data
     # No `ports:` publish — agent is reached by orchestrator via the

--- a/compose.yaml
+++ b/compose.yaml
@@ -380,12 +380,13 @@ services:
       # assumes one operator per process, so going idle = "the
       # operator walked away" → next turn is a fresh conversation.
       AGENT_SESSION_IDLE_SEC: "${AGENT_SESSION_IDLE_SEC:-600}"
-      # Feature flag for tool-calling (issue #19). Default off so this
-      # is a strict no-op until you opt in. When on, the chat graph
-      # becomes a ReAct agent (LLM ↔ tool loop) with the tools defined
-      # in agent/tools.py; when off, the legacy single-node chat graph
-      # is used (bit-for-bit identical to pre-#19 behaviour).
-      AGENT_TOOLS_ENABLED: "${AGENT_TOOLS_ENABLED:-false}"
+      # Feature flag for tool-calling (issue #19). Default on — the
+      # tool-augmented ReAct agent (LLM ↔ tool loop) is the intended
+      # mode now that step 1-5 have landed. Set `AGENT_TOOLS_ENABLED=false`
+      # in `.env` to fall back to the legacy single-node chat graph
+      # (no tools, bit-for-bit identical to pre-#19 behaviour) for A/B
+      # testing or debugging tool-side regressions.
+      AGENT_TOOLS_ENABLED: "${AGENT_TOOLS_ENABLED:-true}"
       # Caps the agent_node → tools → agent_node loop per turn. 6 ≈ up
       # to 3 chained tool calls before we surface the fallback line
       # below. Prevents an infinite retry loop on a tool that always

--- a/compose.yaml
+++ b/compose.yaml
@@ -404,18 +404,20 @@ services:
       # tool's description at agent startup so the LLM sees the actual
       # set it's allowed to call (override the env → restart agent →
       # LLM sees the new list).
-      AGENT_SHELL_ALLOWLIST: "${AGENT_SHELL_ALLOWLIST:-date,ls,cat}"
+      AGENT_SHELL_ALLOWLIST: "${AGENT_SHELL_ALLOWLIST:-ls,date,pwd}"
       # read_file tool — absolute path *inside the container* that the
       # agent may read from. Files outside this root (including via
-      # `..` or symlinks) are rejected by the sandbox. Empty = read_file
-      # is effectively disabled (every call rejects with "not
-      # configured"). To actually expose host files: set this env to
-      # the container path you'll mount, AND add a bind-mount line to
-      # `volumes:` below, e.g.
+      # `..` or symlinks) are rejected by the sandbox. Also used as
+      # `run_shell` の cwd so `ls` / `cat` operate on the same dir.
+      # Default `/app` lets read_file work out of the box (agent's own
+      # code is readable via run_shell's `ls` anyway, so no extra
+      # exposure). For a real share dir, set this to the container
+      # path you'll bind-mount and add the mount under `volumes:`:
       #     - /home/me/voice-share:/workspace/share:ro
-      # The `:ro` suffix is recommended — read_file never writes, and
-      # ro guards against any future tool that might.
-      AGENT_FILE_ROOT: "${AGENT_FILE_ROOT:-}"
+      # then `AGENT_FILE_ROOT=/workspace/share` in `.env`. `:ro` is
+      # recommended — read_file never writes, ro guards against any
+      # future tool that might.
+      AGENT_FILE_ROOT: "${AGENT_FILE_ROOT:-/app}"
       # web_search tool — filler ack phrase the agent emits before the
       # actual DuckDuckGo round-trip, so the voice agent doesn't go
       # silent for the ~1-2 s search latency. Set empty to disable

--- a/compose.yaml
+++ b/compose.yaml
@@ -409,15 +409,23 @@ services:
       # agent may read from. Files outside this root (including via
       # `..` or symlinks) are rejected by the sandbox. Also used as
       # `run_shell` の cwd so `ls` / `cat` operate on the same dir.
-      # Default `/app` lets read_file work out of the box (agent's own
-      # code is readable via run_shell's `ls` anyway, so no extra
-      # exposure). For a real share dir, set this to the container
-      # path you'll bind-mount and add the mount under `volumes:`:
-      #     - /home/me/voice-share:/workspace/share:ro
-      # then `AGENT_FILE_ROOT=/workspace/share` in `.env`. `:ro` is
-      # recommended — read_file never writes, ro guards against any
-      # future tool that might.
-      AGENT_FILE_ROOT: "${AGENT_FILE_ROOT:-/app}"
+      # Default `/workspace` is the parent of the host share mount
+      # (`AGENT_SHARE_DIR` below → `/workspace/share:ro`), so the agent
+      # can `ls share/` and `cat share/foo.txt` out of the box. Set to
+      # `/workspace/share` to confine access to just the share dir, or
+      # to `/app` to expose the agent's own code instead.
+      AGENT_FILE_ROOT: "${AGENT_FILE_ROOT:-/workspace}"
+      # Host directory mounted into the agent container at
+      # `/workspace/share` (read-only) so `read_file` / `run_shell` can
+      # see files the operator drops in from the host side. Default
+      # `./share` is auto-created by Docker on first up (owned by root,
+      # which is fine since the mount is `:ro`). Override in `.env` to
+      # point at an existing share dir, e.g.
+      #     AGENT_SHARE_DIR=/home/me/voice-share
+      # `:ro` is hard-coded — read_file never writes, and ro guards
+      # against any future tool that might. If you need rw, change the
+      # mount line in this file directly.
+      AGENT_SHARE_DIR: "${AGENT_SHARE_DIR:-./share}"
       # web_search tool — filler ack phrase the agent emits before the
       # actual DuckDuckGo round-trip, so the voice agent doesn't go
       # silent for the ~1-2 s search latency. Set empty to disable
@@ -447,6 +455,9 @@ services:
       AGENT_TOOL_ACK_PLAY_AUDIO: "${AGENT_TOOL_ACK_PLAY_AUDIO:-音声を再生するね。}"
     volumes:
       - agent-data:/data
+      # Host share dir → /workspace/share (read-only). The host path is
+      # taken from AGENT_SHARE_DIR (see env block above for docs).
+      - "${AGENT_SHARE_DIR:-./share}:/workspace/share:ro"
     # No `ports:` publish — agent is reached by orchestrator via the
     # compose network (http://agent:7080). Keeping the port internal
     # means the unauthenticated /api/chat surface isn't exposed on the


### PR DESCRIPTION
## Summary

`claude/20260512` ブランチの作業一式。エージェントの tool-calling 基盤（issue #19）と、音声入出力まわり（audio-io の並列 playback track、`play_audio_file` / `stop_audio` tool）をまとめて入れる。

### エージェント tool-calling 基盤 (issue #19)
- tool-calling 基盤 + `run_shell` / `read_file` / `web_search` tool、`sandbox.py`（allowlist / path root 制限）
- tool 例外を string 化して ReAct ループの state 破壊（INVALID_CHAT_HISTORY）を防止
- `AGENT_TOOL_SYSTEM_SUFFIX` の env 化、tool 説明文の動的生成・英語化
- experiments（chat REPL / tool-calling probe）と各種 docs

### 音声出力 (audio-io + agent)
- audio-io: **N 並列 playback track**対応（track ごとに独立 cpal stream / ring / producer、OS mixer でミックス）。`/spk?track=N`、`/spk/stop?track=N`
- `play_audio_file` tool: WAV → audio-io `/spk` track 1 へ realtime ペーシング送出、rate/channels 自動変換、drain handshake
- **複数ファイルのギャップレス連続再生**（1 tool call で `paths: list[str]`、全件検証後に単一接続で連結再生、合計時間で上限判定）
- **`stop_audio` tool**: `play_audio_file` の track を flush（`AGENT_AUDIO_IO_SPK_URL` から `/spk/stop?track=N` を導出）。TTS（別 track）は止めない

### その他
- tool 成功直後の無音では apology fallback を出さない（action-only コマンドで謝罪する矛盾を解消）
- compose / `.env.example` / Dockerfile の配線、`AGENT_FILE_ROOT` 等

## Test plan
- [ ] `python tools.py <tool>` で各 tool を手叩き確認（run_shell / read_file / web_search / play_audio_file / stop_audio）
- [ ] `play_audio_file` で単一・複数 WAV のギャップレス再生、rate/channels 変換、合計時間上限、欠損ファイルの事前検証
- [ ] `stop_audio` で track 1 のみ停止・TTS（track 0）が継続すること
- [ ] audio-io: 複数 track の同時再生が OS mixer でミックスされること
- [ ] エージェント経由（LangGraph）で tool が呼ばれ、成功時に apology fallback が出ないこと
- [ ] `agent/test_sandbox.py` の通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)